### PR TITLE
[FO - #5] 공용 AppHeader 및 헤더용 UI 컴포넌트 추가

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -11,8 +11,7 @@ const MyPage = () => <div className="p-20 text-center">👤 마이페이지 (로
 
 function App() {
   // Zustand 스토어에서 로그인 상태와 상태 검사 함수 꺼내오기
-  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
-  const checkAuth = useAuthStore((state) => state.checkAuth);
+  const { isLoggedIn, checkAuth } = useAuthStore();
 
   // 앱이 처음 렌더링될 때(새로고침 등) 로컬 스토리지 확인해서 로그인 상태 유지
   useEffect(() => {

--- a/src/components/brand/SkillTetrisLogo.tsx
+++ b/src/components/brand/SkillTetrisLogo.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+
+type SkillTetrisLogoProps = {
+  className?: string;
+};
+
+/** "Skill" + 오렌지 "Tetris" 브랜드 마크. 기본 동작: 홈(/)으로 이동 */
+export default function SkillTetrisLogo({ className = '' }: SkillTetrisLogoProps) {
+  return (
+    <Link
+      to="/"
+      className={`text-xl font-black tracking-tighter text-zinc-900 transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-500 rounded-sm ${className}`}
+    >
+      <span className="text-zinc-900">Skill</span>
+      <span className="text-orange-500">Tetris</span>
+    </Link>
+  );
+}

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,0 +1,36 @@
+import SkillTetrisLogo from '../brand/SkillTetrisLogo';
+import { Button } from '../ui/Button';
+import { useAuthStore } from '../../store/authStore';
+
+export default function AppHeader() {
+  const { isLoggedIn, logout } = useAuthStore();
+
+  return (
+    <header className="sticky top-0 z-50 w-full border-b border-zinc-100 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/85">
+      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:h-16 sm:px-6">
+        <SkillTetrisLogo />
+        <nav className="flex items-center gap-2 sm:gap-3" aria-label="계정">
+          {!isLoggedIn ? (
+            <>
+              <Button variant="secondary" to="/login">
+                로그인
+              </Button>
+              <Button variant="secondary" to="/mypage">
+                마이페이지
+              </Button>
+            </>
+          ) : (
+            <>
+              <Button variant="secondary" to="/mypage">
+                마이페이지
+              </Button>
+              <Button variant="primary" onClick={logout}>
+                로그아웃
+              </Button>
+            </>
+          )}
+        </nav>
+      </div>
+    </header>
+  );
+}

--- a/src/components/ui/Button.tsx
+++ b/src/components/ui/Button.tsx
@@ -1,0 +1,54 @@
+import { Link } from 'react-router-dom';
+import type { ButtonHTMLAttributes, ReactNode } from 'react';
+
+const baseClass =
+  'inline-flex items-center justify-center rounded-full px-5 py-2.5 text-sm font-bold transition-colors focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-500 disabled:pointer-events-none disabled:opacity-50';
+
+const variantClass = {
+  primary: 'bg-orange-500 text-white hover:bg-orange-600 shadow-lg shadow-orange-500/20',
+  secondary: 'border border-zinc-200 bg-white text-zinc-800 hover:bg-zinc-50',
+} as const;
+
+type Variant = keyof typeof variantClass;
+
+type ButtonOwnProps = {
+  variant?: Variant;
+  className?: string;
+  children: ReactNode;
+};
+
+type ButtonAsLink = ButtonOwnProps & {
+  to: string;
+};
+
+type ButtonAsNative = ButtonOwnProps &
+  Omit<ButtonHTMLAttributes<HTMLButtonElement>, 'className' | 'children'> & {
+    to?: undefined;
+  };
+
+export type ButtonProps = ButtonAsLink | ButtonAsNative;
+
+export function Button(props: ButtonProps) {
+  const variant = props.variant ?? 'primary';
+  const cls = `${baseClass} ${variantClass[variant]} ${props.className ?? ''}`;
+
+  if ('to' in props && props.to) {
+    return (
+      <Link to={props.to} className={cls}>
+        {props.children}
+      </Link>
+    );
+  }
+
+  const { children, variant: _v, className: _c, to: _t, type = 'button', ...rest } =
+    props as ButtonAsNative;
+  void _v;
+  void _c;
+  void _t;
+
+  return (
+    <button type={type} className={cls} {...rest}>
+      {children}
+    </button>
+  );
+}

--- a/src/pages/kakao/KakaoCallback.tsx
+++ b/src/pages/kakao/KakaoCallback.tsx
@@ -5,7 +5,7 @@ import { useAuthStore } from '../../store/authStore';
 export default function KakaoCallback() {
   // const navigate = useNavigate();
 
-  const login = useAuthStore((state) => state.login);
+  const { login } = useAuthStore();
 
   useEffect(() => {
     const code = new URL(window.location.href).searchParams.get('code');

--- a/src/pages/kakao/component/KakaoLoginButton.tsx
+++ b/src/pages/kakao/component/KakaoLoginButton.tsx
@@ -1,8 +1,7 @@
 import { useAuthStore } from '../../../store/authStore';
 
 export default function KakaoLoginButton() {
-  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
-  const logout = useAuthStore((state) => state.logout);
+  const { isLoggedIn, logout } = useAuthStore();
 
   const handleKakaoLogin = () => {
     const REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,44 +1,39 @@
 import { motion, type Variants } from 'framer-motion';
-import FileUpload from "./component/FileUpload";
-import KakaoLoginButton from '../kakao/component/KakaoLoginButton';
+import FileUpload from './component/FileUpload';
+import AppHeader from '../../components/layout/AppHeader';
 
 export default function MainPage() {
   // 공통 텍스트 애니메이션
   const fadeUpItem: Variants = {
     hidden: { opacity: 0, y: 30 },
-    visible: { 
-      opacity: 1, 
-      y: 0, 
-      transition: { duration: 0.8, ease: [0.16, 1, 0.3, 1] } 
-    }
+    visible: {
+      opacity: 1,
+      y: 0,
+      transition: { duration: 0.8, ease: [0.16, 1, 0.3, 1] },
+    },
   };
 
   // 카드 전용 애니메이션
   const smoothCardItem: Variants = {
     hidden: { opacity: 0, scale: 0.9, y: 15 },
-    visible: (custom: number) => ({ 
-      opacity: 1, 
-      scale: 1, 
+    visible: (custom: number) => ({
+      opacity: 1,
+      scale: 1,
       y: 0,
-      transition: { 
-        duration: 0.8, 
+      transition: {
+        duration: 0.8,
         ease: [0.22, 1, 0.36, 1],
-        delay: custom * 0.1
-      }
-    })
+        delay: custom * 0.1,
+      },
+    }),
   };
 
   return (
-    <div className="min-h-screen bg-white text-zinc-900 w-full overflow-x-hidden relative">
+    <div className="min-h-screen bg-white text-zinc-900 w-full overflow-x-hidden">
+      <AppHeader />
 
-      {/* 헤더 영역: 카카오 로그인 버튼 */}
-      <header className="absolute top-0 left-0 w-full p-6 flex justify-end z-50">
-        <KakaoLoginButton />
-      </header>
-
-      <section className="bg-zinc-950 text-white min-h-[90vh] py-24 px-6 flex flex-col items-center justify-center text-center w-full">
-
-        <motion.span 
+      <section className="bg-zinc-950 text-white min-h-[85vh] py-24 px-6 flex flex-col items-center justify-center text-center w-full">
+        <motion.span
           variants={fadeUpItem}
           initial="hidden"
           whileInView="visible"
@@ -47,29 +42,30 @@ export default function MainPage() {
         >
           조조이백배 프로젝트
         </motion.span>
-        
-        <motion.h1 
+
+        <motion.h1
           variants={fadeUpItem}
           initial="hidden"
           whileInView="visible"
           viewport={{ once: false, amount: 0.5 }}
           className="text-5xl md:text-7xl font-black mb-8 tracking-tighter leading-tight w-full max-w-4xl"
         >
-          Next Plan<br />
+          Next Plan
+          <br />
           <span className="text-orange-500">AI 역량 분석</span>
         </motion.h1>
-        
-        <motion.p 
+
+        <motion.p
           variants={fadeUpItem}
           initial="hidden"
           whileInView="visible"
           viewport={{ once: false, amount: 0.5 }}
           className="text-zinc-400 text-lg md:text-xl mb-16 max-w-2xl font-light leading-relaxed mx-auto"
         >
-          이력서와 포트폴리오를 AI가 분석하여 <br className="hidden md:block" /> 
+          이력서와 포트폴리오를 AI가 분석하여 <br className="hidden md:block" />
           당신만의 테트리스 로드맵을 그려드립니다.
         </motion.p>
-        
+
         <motion.div
           variants={fadeUpItem}
           initial="hidden"
@@ -83,9 +79,8 @@ export default function MainPage() {
 
       <section className="bg-white py-40 px-6 w-full flex flex-col items-center">
         <div className="w-full max-w-6xl flex flex-col items-center">
-          
-          <motion.div 
-            variants={fadeUpItem} 
+          <motion.div
+            variants={fadeUpItem}
             initial="hidden"
             whileInView="visible"
             viewport={{ once: false, amount: 0.3 }}
@@ -101,19 +96,21 @@ export default function MainPage() {
           </motion.div>
 
           <div className="flex flex-wrap justify-center gap-6 w-full">
-            {['🎯 AI 역량 분석', '🧩 맞춤형 추천', '🧱 테트리스 시각화'].map((text, index) => (
-              <motion.div 
-                key={text}
-                custom={index}
-                variants={smoothCardItem}
-                initial="hidden"
-                whileInView="visible"
-                viewport={{ once: false, amount: 0.2 }}
-                className="px-10 py-12 bg-zinc-50 rounded-[32px] border border-zinc-100 flex items-center justify-center text-xl md:text-2xl font-bold text-zinc-800 shadow-sm hover:shadow-md hover:bg-white transition-shadow duration-300 cursor-default"
-              >
-                {text}
-              </motion.div>
-            ))}
+            {['🎯 AI 역량 분석', '🧩 맞춤형 추천', '🧱 테트리스 시각화'].map(
+              (text, index) => (
+                <motion.div
+                  key={text}
+                  custom={index}
+                  variants={smoothCardItem}
+                  initial="hidden"
+                  whileInView="visible"
+                  viewport={{ once: false, amount: 0.2 }}
+                  className="px-10 py-12 bg-zinc-50 rounded-[32px] border border-zinc-100 flex items-center justify-center text-xl md:text-2xl font-bold text-zinc-800 shadow-sm hover:shadow-md hover:bg-white transition-shadow duration-300 cursor-default"
+                >
+                  {text}
+                </motion.div>
+              ),
+            )}
           </div>
         </div>
       </section>
@@ -121,7 +118,9 @@ export default function MainPage() {
       <footer className="bg-zinc-950 text-zinc-600 py-20 px-10 w-full flex justify-center border-t border-zinc-900">
         <div className="max-w-6xl w-full flex flex-col md:flex-row justify-between items-center md:items-end gap-10 text-center md:text-left">
           <div>
-            <div className="text-2xl font-black text-white mb-3 tracking-tighter">Next Plan</div>
+            <div className="text-2xl font-black text-white mb-3 tracking-tighter">
+              Next Plan
+            </div>
             <p className="text-sm font-light">
               당신의 성장을 시각화합니다. <br />
               _Team 조조이백배_
@@ -129,7 +128,10 @@ export default function MainPage() {
           </div>
           <div className="flex gap-8">
             {['GitHub', 'Email', 'LinkedIn'].map((link) => (
-              <button key={link} className="hover:text-orange-500 transition-colors text-sm font-medium">
+              <button
+                key={link}
+                className="hover:text-orange-500 transition-colors text-sm font-medium"
+              >
                 {link}
               </button>
             ))}

--- a/src/store/authStore.ts
+++ b/src/store/authStore.ts
@@ -10,7 +10,7 @@ interface AuthState {
 export const useAuthStore = create<AuthState>((set) => ({
   isLoggedIn: false,
 
-  login: (token) => {
+  login: (token: string) => {
     localStorage.setItem('accessToken', token);
     set({ isLoggedIn: true });
   },


### PR DESCRIPTION
Summary
- 메인 페이지 상단에 **공용 헤더(AppHeader)**를 적용
- 브랜드 로고(SkillTetrisLogo), 공용 버튼(Button) 컴포넌트를 추가해 헤더에서 재사용
- useAuthStore 사용 방식을 구조 분해로 정리하고, login 인자에 string 타입을 명시해 TypeScript noImplicitAny 빌드 오류를 방지

Behavior

- 비로그인: 헤더에 로그인, 마이페이지 링크
- 로그인: 마이페이지, 로그아웃
- 로고 클릭 시 / 이동

How to test

1. pnpm install
2. pnpm dev
3. / 접속 → 헤더 노출 확인
4. (선택) 카카오 더미 로그인 플로우로 로그인 상태 전환 후 헤더 버튼 변화 확인
5. pnpm build, pnpm lint

Notes

- 메인에서 우상단에 있던 KakaoLoginButton 헤더는 제거되었습니다(로그인 페이지/별도 진입에서 재사용 예정).