### PR TITLE
[FO-8] 프로필 설정 페이지 UI

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -2,6 +2,7 @@ import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useEffect } from 'react';
 import ProtectedRoute from './components/ProtectedRoute';
 import MainPage from './pages/main';
+import ProfileSetupPage from './pages/profile-setup';
 import { useAuthStore } from './store/authStore';
 import KakaoCallback from './pages/kakao/KakaoCallback';
 
@@ -11,8 +12,7 @@ const MyPage = () => <div className="p-20 text-center">👤 마이페이지 (로
 
 function App() {
   // Zustand 스토어에서 로그인 상태와 상태 검사 함수 꺼내오기
-  const isLoggedIn = useAuthStore((state) => state.isLoggedIn);
-  const checkAuth = useAuthStore((state) => state.checkAuth);
+  const { isLoggedIn, checkAuth } = useAuthStore();
 
   // 앱이 처음 렌더링될 때(새로고침 등) 로컬 스토리지 확인해서 로그인 상태 유지
   useEffect(() => {
@@ -26,7 +26,8 @@ function App() {
         <Route path="/" element={<MainPage />} />
         <Route path="/main" element={<MainPage />} />
         <Route path="/login" element={<Login />} />
-        
+        <Route path="/profile-setup" element={<ProfileSetupPage />} />
+
         {/* 카카오 로그인 완료 후 돌아올 콜백 라우트 추가 */}
         <Route path="/auth/kakao/callback" element={<KakaoCallback />} />
 

--- a/src/components/brand/NextPlanLogo.tsx
+++ b/src/components/brand/NextPlanLogo.tsx
@@ -1,0 +1,18 @@
+import { Link } from 'react-router-dom';
+
+type NextPlanLogoProps = {
+  className?: string;
+};
+
+/** NextPlan 워드마크: Next(검정) + Plan(오렌지), 띄어쓰기 없음. 클릭 시 홈(/) */
+export default function NextPlanLogo({ className = '' }: NextPlanLogoProps) {
+  return (
+    <Link
+      to="/"
+      className={`text-xl font-black tracking-tighter transition-opacity hover:opacity-90 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-500 rounded-sm ${className}`}
+    >
+      <span className="text-zinc-900">Next</span>
+      <span className="text-orange-500">Plan</span>
+    </Link>
+  );
+}

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,6 +1,7 @@
 import { motion, type Variants } from 'framer-motion';
 import FileUpload from "./component/FileUpload";
 import KakaoLoginButton from '../kakao/component/KakaoLoginButton';
+import NextPlanLogo from '../../components/brand/NextPlanLogo';
 
 export default function MainPage() {
   // 공통 텍스트 애니메이션
@@ -31,8 +32,9 @@ export default function MainPage() {
   return (
     <div className="min-h-screen bg-white text-zinc-900 w-full overflow-x-hidden relative">
 
-      {/* 헤더 영역: 카카오 로그인 버튼 */}
-      <header className="absolute top-0 left-0 w-full p-6 flex justify-end z-50">
+      {/* 헤더: NextPlan 로고 + 카카오 로그인 */}
+      <header className="absolute top-0 left-0 z-50 flex w-full items-center justify-between p-6">
+        <NextPlanLogo />
         <KakaoLoginButton />
       </header>
 

--- a/src/pages/profile-setup/index.tsx
+++ b/src/pages/profile-setup/index.tsx
@@ -1,0 +1,408 @@
+import { useEffect, useMemo, useRef, useState } from 'react';
+import NextPlanLogo from '../../components/brand/NextPlanLogo';
+
+const JOB_OPTIONS = [
+  'Frontend',
+  'Backend',
+  'Full Stack',
+  'DevOps',
+  'DevSecOps',
+  'Data Analyst',
+  'AI Engineer',
+  'AI and Data Scientist',
+  'Data Engineer',
+  'Android Developer',
+  'Machine Learning Engineer',
+  'PostgreSQL / DBA',
+  'iOS Developer',
+  'Blockchain Developer',
+  'QA Engineer',
+  'Software Architect',
+  'Cyber Security',
+  'UX Designer',
+  'Technical Writer',
+  'Game Developer',
+  'Server Side Game Developer',
+  'MLOps',
+  'Product Manager',
+  'Engineering Manager',
+  'Developer Relations',
+  'BI Analyst',
+] as const;
+
+type TechCatalogItem = {
+  name: string;
+  category: string;
+};
+
+/** 검색·결과 목록용 (이름 + 카테고리 — Skill-based Roadmaps 기준) */
+const TECH_CATALOG: TechCatalogItem[] = [
+  // 언어
+  { name: 'JavaScript', category: '언어' },
+  { name: 'TypeScript', category: '언어' },
+  { name: 'Python', category: '언어' },
+  { name: 'Java', category: '언어' },
+  { name: 'C++', category: '언어' },
+  { name: 'Rust', category: '언어' },
+  { name: 'Go', category: '언어' },
+  { name: 'PHP', category: '언어' },
+  { name: 'Ruby', category: '언어' },
+  { name: 'Kotlin', category: '언어' },
+  { name: 'Swift / SwiftUI', category: '언어' },
+  { name: 'Scala', category: '언어' },
+  { name: 'HTML', category: '언어' },
+  { name: 'CSS', category: '언어' },
+  { name: 'Shell / Bash', category: '언어' },
+  { name: 'SQL', category: '언어' },
+  // 프레임워크 / 라이브러리
+  { name: 'React', category: '프레임워크 / 라이브러리' },
+  { name: 'Vue', category: '프레임워크 / 라이브러리' },
+  { name: 'Angular', category: '프레임워크 / 라이브러리' },
+  { name: 'Next.js', category: '프레임워크 / 라이브러리' },
+  { name: 'React Native', category: '프레임워크 / 라이브러리' },
+  { name: 'Flutter', category: '프레임워크 / 라이브러리' },
+  { name: 'Node.js', category: '프레임워크 / 라이브러리' },
+  { name: 'ASP.NET Core', category: '프레임워크 / 라이브러리' },
+  { name: 'Spring Boot', category: '프레임워크 / 라이브러리' },
+  { name: 'Django', category: '프레임워크 / 라이브러리' },
+  { name: 'Laravel', category: '프레임워크 / 라이브러리' },
+  { name: 'Ruby on Rails', category: '프레임워크 / 라이브러리' },
+  // 인프라 / 클라우드 / DevOps
+  { name: 'Docker', category: '인프라 / 클라우드 / DevOps' },
+  { name: 'Kubernetes', category: '인프라 / 클라우드 / DevOps' },
+  { name: 'AWS', category: '인프라 / 클라우드 / DevOps' },
+  { name: 'Terraform', category: '인프라 / 클라우드 / DevOps' },
+  { name: 'Linux', category: '인프라 / 클라우드 / DevOps' },
+  { name: 'Cloudflare', category: '인프라 / 클라우드 / DevOps' },
+  { name: 'Git / GitHub', category: '인프라 / 클라우드 / DevOps' },
+  // 데이터베이스
+  { name: 'PostgreSQL', category: '데이터베이스' },
+  { name: 'MongoDB', category: '데이터베이스' },
+  { name: 'Redis', category: '데이터베이스' },
+  { name: 'Elasticsearch', category: '데이터베이스' },
+  // AI / ML
+  { name: 'Prompt Engineering', category: 'AI / ML' },
+  { name: 'AI Agents', category: 'AI / ML' },
+  { name: 'AI Red Teaming', category: 'AI / ML' },
+  // 기타
+  { name: 'GraphQL', category: '기타' },
+  { name: 'API Design', category: '기타' },
+  { name: 'System Design', category: '기타' },
+  { name: 'Software Design & Architecture', category: '기타' },
+  { name: 'Design System', category: '기타' },
+  { name: 'Computer Science', category: '기타' },
+  { name: 'Data Structures & Algorithms', category: '기타' },
+  { name: 'Code Review', category: '기타' },
+  { name: 'WordPress', category: '기타' },
+  { name: 'Claude Code', category: '기타' },
+  { name: 'Vibe Coding', category: '기타' },
+  { name: 'OpenClaw', category: '기타' },
+];
+
+const MAX_STACK = 15;
+
+function ChevronDownIcon({ className = '' }: { className?: string }) {
+  return (
+    <svg
+      className={className}
+      width="20"
+      height="20"
+      viewBox="0 0 20 20"
+      fill="none"
+      xmlns="http://www.w3.org/2000/svg"
+      aria-hidden
+    >
+      <path
+        d="M5 7.5L10 12.5L15 7.5"
+        stroke="currentColor"
+        strokeWidth="1.75"
+        strokeLinecap="round"
+        strokeLinejoin="round"
+      />
+    </svg>
+  );
+}
+
+export default function ProfileSetupPage() {
+  const [jobRole, setJobRole] = useState<string>(JOB_OPTIONS[0]);
+  const [jobDropdownOpen, setJobDropdownOpen] = useState(false);
+  const jobSelectRef = useRef<HTMLDivElement>(null);
+
+  useEffect(() => {
+    if (!jobDropdownOpen) return;
+    const close = (e: MouseEvent) => {
+      if (jobSelectRef.current && !jobSelectRef.current.contains(e.target as Node)) {
+        setJobDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
+  }, [jobDropdownOpen]);
+
+  const [selectedStacks, setSelectedStacks] = useState<string[]>([
+    'React',
+    'TypeScript',
+    'Next.js',
+    'Python',
+  ]);
+  const [stackQuery, setStackQuery] = useState('');
+
+  const selectedSet = useMemo(() => new Set(selectedStacks), [selectedStacks]);
+
+  const filteredCatalog = useMemo(() => {
+    const q = stackQuery.trim().toLowerCase();
+    if (!q) return [];
+    return TECH_CATALOG.filter(
+      (item) =>
+        item.name.toLowerCase().includes(q) || item.category.toLowerCase().includes(q)
+    );
+  }, [stackQuery]);
+
+  const addStack = (name: string) => {
+    setSelectedStacks((prev) => {
+      if (prev.includes(name)) return prev;
+      if (prev.length >= MAX_STACK) return prev;
+      return [...prev, name];
+    });
+  };
+
+  const removeStack = (name: string) => {
+    setSelectedStacks((prev) => prev.filter((s) => s !== name));
+  };
+
+  return (
+    <div className="min-h-screen bg-zinc-100 px-4 py-10 text-zinc-900">
+      <div className="mx-auto flex w-full max-w-lg flex-col items-center">
+        <div className="mb-8 flex justify-center">
+          <NextPlanLogo className="text-2xl" />
+        </div>
+
+        <div className="w-full rounded-3xl border border-zinc-200/80 bg-white px-6 py-10 shadow-sm sm:px-10">
+          <h1 className="text-center text-2xl font-black tracking-tight text-zinc-900 sm:text-3xl">
+            프로필 설정
+          </h1>
+          <p className="mt-2 text-center text-sm text-zinc-500 sm:text-base">
+            더 정확한 AI 분석을 위해 기본 정보를 입력해주세요
+          </p>
+
+          {/* 스테퍼 */}
+          <div className="mt-10 flex items-center justify-center gap-2 sm:gap-4">
+            <div className="flex flex-col items-center gap-1.5">
+              <span className="flex h-9 w-9 items-center justify-center rounded-full border border-zinc-200 bg-zinc-100 text-sm font-bold text-zinc-400">
+                1
+              </span>
+              <span className="text-xs font-medium text-zinc-400 sm:text-sm">카카오 인증</span>
+            </div>
+            <div className="mx-1 h-px w-8 bg-zinc-200 sm:w-12" aria-hidden />
+            <div className="flex flex-col items-center gap-1.5">
+              <span className="flex h-9 w-9 items-center justify-center rounded-full bg-orange-500 text-sm font-bold text-white shadow-md shadow-orange-500/25">
+                2
+              </span>
+              <span className="text-xs font-semibold text-orange-500 sm:text-sm">프로필 설정</span>
+            </div>
+          </div>
+
+          {/* 희망 직군 — 커스텀 단일 선택 (화살표 + 목록 내 체크) */}
+          <div className="mt-10" ref={jobSelectRef}>
+            <div className="mb-2 flex items-center gap-1.5">
+              <span id="job-role-label" className="text-sm font-bold text-zinc-900">
+                희망 직군
+              </span>
+              <ChevronDownIcon className="h-4 w-4 shrink-0 text-zinc-400" />
+            </div>
+            <div className="relative">
+              <button
+                type="button"
+                id="job-role-trigger"
+                aria-labelledby="job-role-label"
+                aria-haspopup="listbox"
+                aria-expanded={jobDropdownOpen}
+                onClick={() => setJobDropdownOpen((o) => !o)}
+                className="flex w-full items-center justify-between gap-3 rounded-2xl border border-zinc-200 bg-zinc-50 px-4 py-3.5 text-left text-sm font-medium text-zinc-900 outline-none transition-colors hover:border-zinc-300 focus-visible:border-orange-400 focus-visible:ring-2 focus-visible:ring-orange-500/20"
+              >
+                <span className="min-w-0 truncate">{jobRole}</span>
+                <ChevronDownIcon
+                  className={`shrink-0 text-zinc-400 transition-transform ${jobDropdownOpen ? 'rotate-180' : ''}`}
+                />
+              </button>
+              {jobDropdownOpen && (
+                <ul
+                  role="listbox"
+                  aria-labelledby="job-role-label"
+                  className="absolute left-0 right-0 top-full z-20 mt-1 max-h-64 overflow-auto rounded-2xl border border-zinc-200 bg-white py-1 shadow-lg shadow-zinc-900/10"
+                >
+                  {JOB_OPTIONS.map((job) => {
+                    const selected = job === jobRole;
+                    return (
+                      <li key={job} role="presentation">
+                        <button
+                          type="button"
+                          role="option"
+                          aria-selected={selected}
+                          onClick={() => {
+                            setJobRole(job);
+                            setJobDropdownOpen(false);
+                          }}
+                          className={`flex w-full items-center justify-between gap-3 px-4 py-3 text-left text-sm transition-colors ${
+                            selected
+                              ? 'bg-orange-50 font-semibold text-orange-600'
+                              : 'text-zinc-900 hover:bg-zinc-50'
+                          }`}
+                        >
+                          <span className="truncate">{job}</span>
+                          {selected ? (
+                            <span className="shrink-0 text-orange-500" aria-hidden>
+                              ✓
+                            </span>
+                          ) : (
+                            <span className="w-5 shrink-0" aria-hidden />
+                          )}
+                        </button>
+                      </li>
+                    );
+                  })}
+                </ul>
+              )}
+            </div>
+          </div>
+
+          {/* 기술 스택 */}
+          <div className="mt-8">
+            <div className="mb-1 flex flex-wrap items-baseline justify-between gap-2">
+              <span className="text-sm font-bold text-zinc-900">기술 스택</span>
+              <span className="text-xs text-zinc-500">
+                {selectedStacks.length} / {MAX_STACK}개 선택됨
+              </span>
+            </div>
+            <p className="mb-3 text-xs text-zinc-500 sm:text-sm">
+              기술을 입력하면 연관 검색어가 표시됩니다 (최대 {MAX_STACK}개)
+            </p>
+
+            {/* 선택된 태그: flex-wrap */}
+            <div
+              className="mb-3 flex min-h-[2.75rem] flex-wrap gap-2 rounded-2xl border border-dashed border-zinc-200 bg-zinc-50/80 p-3"
+              aria-label="선택된 기술 스택"
+            >
+              {selectedStacks.length === 0 ? (
+                <span className="text-sm text-zinc-400">선택된 기술이 없습니다</span>
+              ) : (
+                selectedStacks.map((name) => (
+                  <span
+                    key={name}
+                    className="inline-flex items-center gap-1 rounded-full bg-orange-100 px-3 py-1.5 text-sm font-semibold text-orange-800"
+                  >
+                    {name}
+                    <button
+                      type="button"
+                      onClick={() => removeStack(name)}
+                      className="ml-0.5 rounded-full p-0.5 text-orange-700 hover:bg-orange-200/80"
+                      aria-label={`${name} 제거`}
+                    >
+                      ×
+                    </button>
+                  </span>
+                ))
+              )}
+            </div>
+
+            {/* 검색 입력 */}
+            <div className="relative">
+              <span
+                className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-zinc-400"
+                aria-hidden
+              >
+                🔍
+              </span>
+              <input
+                type="search"
+                value={stackQuery}
+                onChange={(e) => setStackQuery(e.target.value)}
+                placeholder="기술 이름을 검색하세요"
+                autoComplete="off"
+                className="w-full rounded-2xl border border-zinc-200 bg-zinc-50 py-3 pl-10 pr-4 text-sm text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-orange-400 focus:bg-white focus:ring-2 focus:ring-orange-500/20"
+                aria-label="기술 스택 검색"
+              />
+            </div>
+
+            {/* 검색 결과 */}
+            {stackQuery.trim().length > 0 && (
+              <div
+                className="mt-2 overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm"
+                role="listbox"
+                aria-label="검색 결과"
+              >
+                {filteredCatalog.length === 0 ? (
+                  <p className="px-4 py-6 text-center text-sm text-zinc-500">검색 결과가 없습니다</p>
+                ) : (
+                  <ul className="max-h-64 divide-y divide-zinc-100 overflow-y-auto">
+                    {filteredCatalog.map((item) => {
+                      const added = selectedSet.has(item.name);
+                      const atLimit = selectedStacks.length >= MAX_STACK;
+                      return (
+                        <li key={item.name}>
+                          <div
+                            className={`flex items-center justify-between gap-3 px-3 py-2.5 sm:px-4 ${
+                              added ? 'bg-orange-50/90' : 'bg-white'
+                            }`}
+                          >
+                            <div className="min-w-0 flex-1">
+                              <div className="flex items-start gap-2">
+                                <span
+                                  className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-zinc-100 text-xs font-mono text-zinc-500"
+                                  aria-hidden
+                                >
+                                  {'</>'}
+                                </span>
+                                <div className="min-w-0">
+                                  <p className="truncate text-sm font-bold text-zinc-900">{item.name}</p>
+                                  <p className="truncate text-xs text-zinc-500">{item.category}</p>
+                                </div>
+                              </div>
+                            </div>
+                            <div className="shrink-0">
+                              {added ? (
+                                <span className="rounded-full bg-orange-100 px-2.5 py-1 text-xs font-bold text-orange-700">
+                                  추가됨
+                                </span>
+                              ) : (
+                                <button
+                                  type="button"
+                                  disabled={atLimit}
+                                  onClick={() => addStack(item.name)}
+                                  className="flex h-8 w-8 items-center justify-center rounded-full border border-zinc-200 text-lg font-medium text-zinc-600 transition-colors hover:border-orange-300 hover:bg-orange-50 hover:text-orange-600 disabled:cursor-not-allowed disabled:opacity-40"
+                                  aria-label={`${item.name} 추가`}
+                                >
+                                  +
+                                </button>
+                              )}
+                            </div>
+                          </div>
+                        </li>
+                      );
+                    })}
+                  </ul>
+                )}
+                <div className="flex justify-end border-t border-zinc-100 bg-zinc-50/80 px-3 py-2 text-xs text-zinc-500">
+                  {selectedStacks.length} / {MAX_STACK}개 선택됨
+                </div>
+              </div>
+            )}
+          </div>
+
+          <button
+            type="button"
+            className="mt-10 w-full rounded-full bg-orange-500 py-3.5 text-sm font-bold text-white shadow-lg shadow-orange-500/25 transition-colors hover:bg-orange-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-500"
+          >
+            완료
+          </button>
+          <button
+            type="button"
+            className="mt-4 w-full text-center text-sm font-medium text-zinc-500 underline-offset-2 hover:text-zinc-700 hover:underline"
+          >
+            나중에 설정하기
+          </button>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/pages/profile-setup/index.tsx
+++ b/src/pages/profile-setup/index.tsx
@@ -346,18 +346,8 @@ export default function ProfileSetupPage() {
                             }`}
                           >
                             <div className="min-w-0 flex-1">
-                              <div className="flex items-start gap-2">
-                                <span
-                                  className="mt-0.5 flex h-8 w-8 shrink-0 items-center justify-center rounded-lg bg-zinc-100 text-xs font-mono text-zinc-500"
-                                  aria-hidden
-                                >
-                                  {'</>'}
-                                </span>
-                                <div className="min-w-0">
-                                  <p className="truncate text-sm font-bold text-zinc-900">{item.name}</p>
-                                  <p className="truncate text-xs text-zinc-500">{item.category}</p>
-                                </div>
-                              </div>
+                              <p className="truncate text-sm font-bold text-zinc-900">{item.name}</p>
+                              <p className="truncate text-xs text-zinc-500">{item.category}</p>
                             </div>
                             <div className="shrink-0">
                               {added ? (


### PR DESCRIPTION
<img width="1790" height="765" alt="pro-nextplan" src="https://github.com/user-attachments/assets/e01674a9-fc51-4986-9d7f-02ec83259a9b" />

Summary
- NextPlanLogo.tsx 추가했습니다.
- /profile-setup 공개 라우트와 프로필 설정 화면 UI를 추가했습니다.
- 희망 직군: 네이티브 <select> 대신 커스텀 단일 선택 — 라벨 옆·트리거에 화살표, 목록에서 선택 항목 체크(✓) 및 주황 강조.

- 기술 스택: 검색어 필터 + 결과 목록에서 추가 / 추가됨 표시, 선택 태그 영역 flex-wrap, 최대 15개 제한.

- 데이터: Role-based 직군 26개, Skill-based 기술 54개 적용

- 기타: 검색 결과 행의 플레이스홀더

-  아이콘 제거 (design 커밋). 상단 브랜드는 기존 NextPlanLogo 재사용.


