### PR TITLE
[FO-#10] 프로필 설정 카드 너비 반응형 개선

### DIFF
--- a/src/pages/profile-setup/index.tsx
+++ b/src/pages/profile-setup/index.tsx
@@ -172,7 +172,7 @@ export default function ProfileSetupPage() {
 
   return (
     <div className="min-h-screen bg-zinc-100 px-4 py-10 text-zinc-900">
-      <div className="mx-auto flex w-full max-w-lg flex-col items-center">
+      <div className="mx-auto flex w-full max-w-lg flex-col items-center sm:max-w-xl md:max-w-2xl lg:max-w-3xl">
         <div className="mb-8 flex justify-center">
           <NextPlanLogo className="text-2xl" />
         </div>


### PR DESCRIPTION
Summary
프로필 설정(/profile-setup) 화면에서 중앙 카드가 넓은 화면에서도 좌·우 여백이 과하게 비어 보이던 문제를 개선했습니다.
카드 래퍼에 브레이크포인트별 max-width 를 적용해, 화면이 넓어질수록 카드 너비가 단계적으로 넓어지도록 했습니다.
모바일·작은 화면은 기존과 동일하게 max-w-lg 기준을 유지합니다.