### PR TITLE
[FO-#11] 메인 페이지 헤더(AppHeader) 및 로고 가시성 개선

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
 import { BrowserRouter, Routes, Route, Navigate } from 'react-router-dom';
 import { useEffect } from 'react';
+import AppLayout from './components/layout/AppLayout';
 import ProtectedRoute from './components/ProtectedRoute';
 import MainPage from './pages/main';
 import ProfileSetupPage from './pages/profile-setup';
@@ -26,26 +27,24 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        {/* --- 공개 페이지 --- */}
-        <Route path="/" element={<MainPage />} />
-        <Route path="/main" element={<MainPage />} />
-        <Route path="/login" element={<Login />} />
-        <Route path="/profile-setup" element={<ProfileSetupPage />} />
-
-        {/* 카카오 로그인 완료 후 돌아올 콜백 라우트 */}
+        {/* 헤더 없음: 로그인 처리 전용 화면 */}
         <Route path="/auth/kakao/callback" element={<KakaoCallback />} />
 
-        <Route path="/board/:category" element={<BoardPage />} />
-        <Route path="/board/:category/:id" element={<BoardDetailPage />} />
+        <Route element={<AppLayout />}>
+          <Route path="/" element={<MainPage />} />
+          <Route path="/main" element={<MainPage />} />
+          <Route path="/login" element={<Login />} />
+          <Route path="/profile-setup" element={<ProfileSetupPage />} />
+          <Route path="/board/:category" element={<BoardPage />} />
+          <Route path="/board/:category/:id" element={<BoardDetailPage />} />
 
-        {/* --- 보호된 페이지 --- */}
-        <Route element={<ProtectedRoute isAuthenticated={isLoggedIn} />}>
-          <Route path="/mypage" element={<MyPage />} />
-          <Route path="/result/:id" element={<ResultPage />} />
-          <Route path="/result" element={<Navigate to="/" replace />} />
+          <Route element={<ProtectedRoute isAuthenticated={isLoggedIn} />}>
+            <Route path="/mypage" element={<MyPage />} />
+            <Route path="/result/:id" element={<ResultPage />} />
+            <Route path="/result" element={<Navigate to="/" replace />} />
+          </Route>
         </Route>
 
-        {/* --- 예외 처리 --- */}
         <Route path="*" element={<Navigate to="/" replace />} />
       </Routes>
     </BrowserRouter>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -27,14 +27,14 @@ function App() {
   return (
     <BrowserRouter>
       <Routes>
-        {/* 헤더 없음: 로그인 처리 전용 화면 */}
+        {/* 전역 헤더 없음 */}
         <Route path="/auth/kakao/callback" element={<KakaoCallback />} />
+        <Route path="/profile-setup" element={<ProfileSetupPage />} />
 
         <Route element={<AppLayout />}>
           <Route path="/" element={<MainPage />} />
           <Route path="/main" element={<MainPage />} />
           <Route path="/login" element={<Login />} />
-          <Route path="/profile-setup" element={<ProfileSetupPage />} />
           <Route path="/board/:category" element={<BoardPage />} />
           <Route path="/board/:category/:id" element={<BoardDetailPage />} />
 

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -8,7 +8,7 @@ type AppHeaderProps = {
 
 export default function AppHeader({ rightSlot }: AppHeaderProps) {
   return (
-    <header className="sticky top-0 z-50 w-full border-b border-zinc-100 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/85">
+    <header className="sticky top-0 z-50 w-full border-b border-zinc-100 bg-white">
       <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:h-16 sm:px-6">
         <NextPlanLogo />
         {rightSlot ? (

--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -1,44 +1,21 @@
-import SkillTetrisLogo from '../brand/SkillTetrisLogo';
-import { Button } from '../ui/Button';
-import { useAuthStore } from '../../store/authStore';
+import type { ReactNode } from 'react';
+import NextPlanLogo from '../brand/NextPlanLogo';
 
-export default function AppHeader() {
-  const { isLoggedIn, logout } = useAuthStore();
+type AppHeaderProps = {
+  /** 메인 등 페이지별 오른쪽 액션 (예: KakaoLoginButton) */
+  rightSlot?: ReactNode;
+};
 
-  const handleKakaoLogin = () => {
-    const REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
-    const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
-    
-    const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
-
-    window.location.href = KAKAO_AUTH_URL;
-  };
-
+export default function AppHeader({ rightSlot }: AppHeaderProps) {
   return (
     <header className="sticky top-0 z-50 w-full border-b border-zinc-100 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/85">
       <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:h-16 sm:px-6">
-        <SkillTetrisLogo />
-        <nav className="flex items-center gap-2 sm:gap-3" aria-label="계정">
-          {!isLoggedIn ? (
-            <>
-              <Button variant="primary" onClick={handleKakaoLogin}>
-                로그인
-              </Button>
-              <Button variant="secondary" to="/mypage">
-                마이페이지
-              </Button>
-            </>
-          ) : (
-            <>
-              <Button variant="secondary" to="/mypage">
-                마이페이지
-              </Button>
-              <Button variant="primary" onClick={logout}>
-                로그아웃
-              </Button>
-            </>
-          )}
-        </nav>
+        <NextPlanLogo />
+        {rightSlot ? (
+          <nav className="flex items-center gap-2 sm:gap-3" aria-label="계정">
+            {rightSlot}
+          </nav>
+        ) : null}
       </div>
     </header>
   );

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,0 +1,13 @@
+import { Outlet } from 'react-router-dom';
+import AppHeader from './AppHeader';
+import KakaoLoginButton from '../../pages/kakao/component/KakaoLoginButton';
+
+/** 전역 NAV: AppHeader + 페이지 본문(Outlet) */
+export default function AppLayout() {
+  return (
+    <>
+      <AppHeader rightSlot={<KakaoLoginButton />} />
+      <Outlet />
+    </>
+  );
+}

--- a/src/pages/kakao/component/KakaoLoginButton.tsx
+++ b/src/pages/kakao/component/KakaoLoginButton.tsx
@@ -1,3 +1,4 @@
+import { Button } from '../../../components/ui/Button';
 import { useAuthStore } from '../../../store/authStore';
 
 export default function KakaoLoginButton() {
@@ -12,15 +13,16 @@ export default function KakaoLoginButton() {
     window.location.href = KAKAO_AUTH_URL;
   };
 
-  // 로그인 상태일 때: 로그아웃 버튼 보여주기
   if (isLoggedIn) {
     return (
-      <button 
-        onClick={logout}
-        className="flex items-center gap-2 bg-zinc-800 hover:bg-zinc-700 text-white px-5 py-2.5 rounded-full font-bold text-sm transition-colors shadow-lg shadow-black/10"
-      >
-        로그아웃
-      </button>
+      <>
+        <Button variant="secondary" to="/mypage">
+          마이페이지
+        </Button>
+        <Button variant="primary" onClick={logout}>
+          로그아웃
+        </Button>
+      </>
     );
   }
 

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -2,7 +2,7 @@ import { motion, type Variants } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import FileUpload from "./component/FileUpload";
 import KakaoLoginButton from '../kakao/component/KakaoLoginButton';
-import NextPlanLogo from '../../components/brand/NextPlanLogo';
+import AppHeader from '../../components/layout/AppHeader';
 
 export default function MainPage() {
   const navigate = useNavigate();
@@ -33,13 +33,9 @@ export default function MainPage() {
   };
 
   return (
-    <div className="min-h-screen bg-white text-zinc-900 w-full overflow-x-hidden relative">
+    <div className="min-h-screen bg-white text-zinc-900 w-full overflow-x-hidden">
 
-      {/* 헤더: NextPlan 로고 + 카카오 로그인 */}
-      <header className="absolute top-0 left-0 z-50 flex w-full items-center justify-between p-6">
-        <NextPlanLogo />
-        <KakaoLoginButton />
-      </header>
+      <AppHeader rightSlot={<KakaoLoginButton />} />
 
       <section className="bg-zinc-950 text-white min-h-[90vh] py-24 px-6 flex flex-col items-center justify-center text-center w-full">
         <motion.span

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,9 +1,6 @@
 import { motion, type Variants } from 'framer-motion';
 import { useNavigate } from 'react-router-dom';
 import FileUpload from "./component/FileUpload";
-import KakaoLoginButton from '../kakao/component/KakaoLoginButton';
-import AppHeader from '../../components/layout/AppHeader';
-
 export default function MainPage() {
   const navigate = useNavigate();
 
@@ -34,9 +31,6 @@ export default function MainPage() {
 
   return (
     <div className="min-h-screen bg-white text-zinc-900 w-full overflow-x-hidden">
-
-      <AppHeader rightSlot={<KakaoLoginButton />} />
-
       <section className="bg-zinc-950 text-white min-h-[90vh] py-24 px-6 flex flex-col items-center justify-center text-center w-full">
         <motion.span
           variants={fadeUpItem}


### PR DESCRIPTION
Summary
메인 페이지

- [ ] 상단 투명 absolute 헤더를 제거하고, 디자인 시안과 같이 흰색 sticky AppHeader 를 적용했습니다.
- [ ] NextPlanLogo 를 헤더에 사용해, 다크 히어로 위에서 Next 텍스트가 보이지 않던 문제를 해결했습니다.

Scope

src/components/layout/AppHeader.tsx

- SkillTetrisLogo → NextPlanLogo
- rightSlot prop 추가
- 헤더 내 기본 로그인/마이페이지 버튼 제거 (메인은 rightSlot만 사용)

src/pages/main/index.tsx

- absolute 헤더 제거 → <AppHeader rightSlot={<KakaoLoginButton />} />