### PR TITLE
[FO-#12] 마이페이지 UI 및 GET /api/users/me 연동

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -9,12 +9,11 @@ import KakaoCallback from './pages/kakao/KakaoCallback';
 import ResultPage from './pages/result/index';
 import BoardPage from './pages/board/BoardPage';
 import BoardDetailPage from './pages/board/BoardDetailPage';
+import MyPage from './pages/mypage';
 
 
 // 임시 페이지 컴포넌트들
 const Login = () => <div className="p-20 text-center">🔑 로그인 페이지</div>;
-const MyPage = () => <div className="p-20 text-center">👤 마이페이지 (로그인 성공!)</div>;
-
 function App() {
   // Zustand 스토어에서 로그인 상태와 상태 검사 함수 꺼내오기
   const { isLoggedIn, checkAuth } = useAuthStore();

--- a/src/apis/userApi.ts
+++ b/src/apis/userApi.ts
@@ -1,0 +1,7 @@
+import { api } from './api';
+import type { MyPageResponse } from '../types/mypage';
+
+export async function fetchMyPage(): Promise<MyPageResponse> {
+  const { data } = await api.get<MyPageResponse>('/api/users/me');
+  return data;
+}

--- a/src/pages/mypage/components/AnalysisHistoryCard.tsx
+++ b/src/pages/mypage/components/AnalysisHistoryCard.tsx
@@ -1,0 +1,42 @@
+import { Button } from '../../../components/ui/Button';
+import type { AnalysisRecord } from '../../../types/mypage';
+import { formatKoreanDate } from '../formatDate';
+
+const TAG_STYLES = [
+  'bg-zinc-100 text-zinc-700',
+  'bg-orange-50 text-orange-700',
+  'bg-sky-50 text-sky-700',
+] as const;
+
+type AnalysisHistoryCardProps = {
+  record: AnalysisRecord;
+};
+
+export default function AnalysisHistoryCard({ record }: AnalysisHistoryCardProps) {
+  const metaParts = [formatKoreanDate(record.createdAt)];
+  if (record.fileName) metaParts.push(record.fileName);
+
+  return (
+    <article className="flex flex-col gap-4 rounded-2xl border border-zinc-100 bg-white p-5 shadow-sm shadow-zinc-900/5 sm:flex-row sm:items-center sm:justify-between sm:gap-6 sm:p-6">
+      <div className="min-w-0 flex-1">
+        <h3 className="text-base font-bold text-zinc-900 sm:text-lg">{record.inputSummary}</h3>
+        <p className="mt-1.5 text-sm text-zinc-500">{metaParts.join(' · ')}</p>
+        {record.tags && record.tags.length > 0 && (
+          <ul className="mt-3 flex flex-wrap gap-2" aria-label="관련 기술">
+            {record.tags.map((tag, index) => (
+              <li
+                key={tag}
+                className={`rounded-full px-3 py-1 text-xs font-semibold ${TAG_STYLES[index % TAG_STYLES.length]}`}
+              >
+                {tag}
+              </li>
+            ))}
+          </ul>
+        )}
+      </div>
+      <Button variant="secondary" to={`/result/${record.recordId}`} className="shrink-0 self-start sm:self-center">
+        결과 보기
+      </Button>
+    </article>
+  );
+}

--- a/src/pages/mypage/components/ProfileCard.tsx
+++ b/src/pages/mypage/components/ProfileCard.tsx
@@ -1,0 +1,58 @@
+import type { MyPageResponse } from '../../../types/mypage';
+import { formatKoreanDate } from '../formatDate';
+
+type ProfileCardProps = {
+  data: Pick<MyPageResponse, 'nickname' | 'email' | 'joinedAt' | 'analysisCount'>;
+};
+
+function KakaoBadge() {
+  return (
+    <span className="inline-flex items-center gap-1.5 text-sm font-medium text-zinc-800">
+      <span
+        className="flex h-5 w-5 items-center justify-center rounded-md bg-[#FEE500] text-[10px] font-black text-[#3C1E1E]"
+        aria-hidden
+      >
+        K
+      </span>
+      카카오톡
+    </span>
+  );
+}
+
+export default function ProfileCard({ data }: ProfileCardProps) {
+  const initial = data.nickname.trim().charAt(0) || '?';
+
+  return (
+    <section className="rounded-3xl border border-zinc-100 bg-white p-6 shadow-sm shadow-zinc-900/5 sm:p-8">
+      <div className="flex flex-col items-center text-center">
+        <div
+          className="flex h-24 w-24 items-center justify-center rounded-full bg-orange-500 text-3xl font-bold text-white"
+          aria-hidden
+        >
+          {initial}
+        </div>
+        <h1 className="mt-5 text-xl font-bold text-zinc-900">{data.nickname}</h1>
+        <p className="mt-1 text-sm text-zinc-500">{data.email}</p>
+      </div>
+
+      <dl className="mt-8 space-y-4 border-t border-zinc-100 pt-6">
+        <div className="flex items-center justify-between gap-4">
+          <dt className="text-sm text-zinc-500">로그인 방법</dt>
+          <dd>
+            <KakaoBadge />
+          </dd>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <dt className="text-sm text-zinc-500">가입일</dt>
+          <dd className="text-sm font-semibold text-zinc-900">{formatKoreanDate(data.joinedAt)}</dd>
+        </div>
+        <div className="flex items-center justify-between gap-4">
+          <dt className="text-sm text-zinc-500">분석 횟수</dt>
+          <dd className="text-sm font-semibold text-zinc-900">
+            <span className="text-orange-500">{data.analysisCount}</span>회
+          </dd>
+        </div>
+      </dl>
+    </section>
+  );
+}

--- a/src/pages/mypage/formatDate.ts
+++ b/src/pages/mypage/formatDate.ts
@@ -1,0 +1,8 @@
+export function formatKoreanDate(iso: string): string {
+  const date = new Date(iso);
+  if (Number.isNaN(date.getTime())) return iso;
+  const y = date.getFullYear();
+  const m = String(date.getMonth() + 1).padStart(2, '0');
+  const d = String(date.getDate()).padStart(2, '0');
+  return `${y}.${m}.${d}`;
+}

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,17 +1,12 @@
 import { useCallback, useEffect, useState } from 'react';
-import { useNavigate } from 'react-router-dom';
 import { fetchMyPage } from '../../apis/userApi';
-import NextPlanLogo from '../../components/brand/NextPlanLogo';
 import { Button } from '../../components/ui/Button';
-import { useAuthStore } from '../../store/authStore';
 import type { MyPageResponse } from '../../types/mypage';
 import AnalysisHistoryCard from './components/AnalysisHistoryCard';
 import ProfileCard from './components/ProfileCard';
 import { MOCK_MY_PAGE } from './mockMyPageData';
 
 export default function MyPage() {
-  const navigate = useNavigate();
-  const { logout } = useAuthStore();
   const [data, setData] = useState<MyPageResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
@@ -38,22 +33,8 @@ export default function MyPage() {
     void load();
   }, [load]);
 
-  const handleLogout = () => {
-    logout();
-    navigate('/');
-  };
-
   return (
     <div className="min-h-screen bg-zinc-100 text-zinc-900">
-      <header className="sticky top-0 z-50 border-b border-zinc-100 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/85">
-        <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:h-16 sm:px-6">
-          <NextPlanLogo />
-          <Button variant="primary" onClick={handleLogout}>
-            로그아웃
-          </Button>
-        </div>
-      </header>
-
       <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
         {loading && (
           <p className="py-20 text-center text-sm text-zinc-500" role="status">

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,0 +1,104 @@
+import { useCallback, useEffect, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { fetchMyPage } from '../../apis/userApi';
+import NextPlanLogo from '../../components/brand/NextPlanLogo';
+import { Button } from '../../components/ui/Button';
+import { useAuthStore } from '../../store/authStore';
+import type { MyPageResponse } from '../../types/mypage';
+import AnalysisHistoryCard from './components/AnalysisHistoryCard';
+import ProfileCard from './components/ProfileCard';
+import { MOCK_MY_PAGE } from './mockMyPageData';
+
+export default function MyPage() {
+  const navigate = useNavigate();
+  const { logout } = useAuthStore();
+  const [data, setData] = useState<MyPageResponse | null>(null);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    setError(null);
+    try {
+      const response = await fetchMyPage();
+      setData(response);
+    } catch {
+      if (import.meta.env.DEV) {
+        setData(MOCK_MY_PAGE);
+      } else {
+        setError('마이페이지 정보를 불러오지 못했습니다. 잠시 후 다시 시도해 주세요.');
+        setData(null);
+      }
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    void load();
+  }, [load]);
+
+  const handleLogout = () => {
+    logout();
+    navigate('/');
+  };
+
+  return (
+    <div className="min-h-screen bg-zinc-100 text-zinc-900">
+      <header className="sticky top-0 z-50 border-b border-zinc-100 bg-white/95 backdrop-blur supports-[backdrop-filter]:bg-white/85">
+        <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:h-16 sm:px-6">
+          <NextPlanLogo />
+          <Button variant="primary" onClick={handleLogout}>
+            로그아웃
+          </Button>
+        </div>
+      </header>
+
+      <main className="mx-auto max-w-6xl px-4 py-8 sm:px-6 sm:py-10">
+        {loading && (
+          <p className="py-20 text-center text-sm text-zinc-500" role="status">
+            마이페이지를 불러오는 중…
+          </p>
+        )}
+
+        {!loading && error && (
+          <div className="py-20 text-center">
+            <p className="text-sm text-zinc-600">{error}</p>
+            <Button variant="primary" className="mt-4" onClick={() => void load()}>
+              다시 시도
+            </Button>
+          </div>
+        )}
+
+        {!loading && data && (
+          <div className="grid gap-8 lg:grid-cols-[minmax(0,320px)_1fr] lg:gap-10">
+            <ProfileCard data={data} />
+
+            <section aria-labelledby="analysis-history-heading">
+              <div className="mb-4 flex flex-wrap items-end justify-between gap-2">
+                <h2 id="analysis-history-heading" className="text-lg font-bold text-zinc-900 sm:text-xl">
+                  AI 분석 기록
+                </h2>
+                <p className="text-sm text-zinc-500">총 {data.analysisCount}건</p>
+              </div>
+
+              {data.analysisRecords.length === 0 ? (
+                <p className="rounded-2xl border border-dashed border-zinc-200 bg-white px-6 py-12 text-center text-sm text-zinc-500">
+                  아직 AI 분석 기록이 없습니다.
+                </p>
+              ) : (
+                <ul className="space-y-4">
+                  {data.analysisRecords.map((record) => (
+                    <li key={record.recordId}>
+                      <AnalysisHistoryCard record={record} />
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </section>
+          </div>
+        )}
+      </main>
+    </div>
+  );
+}

--- a/src/pages/mypage/mockMyPageData.ts
+++ b/src/pages/mypage/mockMyPageData.ts
@@ -1,0 +1,38 @@
+import type { MyPageResponse } from '../../types/mypage';
+
+/** 백엔드 미연동 시 개발 환경 UI 확인용 */
+export const MOCK_MY_PAGE: MyPageResponse = {
+  nickname: '김철익',
+  email: 'chulick.kim@kakao.com',
+  joinedAt: '2025-03-15T00:00:00+09:00',
+  analysisCount: 3,
+  analysisRecords: [
+    {
+      recordId: '8e2fd5b6-1bb6-4e21-9c48-1d22b7b50c2d',
+      analysisType: 'resume_review',
+      inputSummary: '프론트엔드 개발자 이력서 분석',
+      result: '',
+      createdAt: '2025-03-28T00:00:00+09:00',
+      fileName: '이력서_김철익.pdf',
+      tags: ['React', 'TypeScript', 'Next.js'],
+    },
+    {
+      recordId: 'a1b2c3d4-e5f6-7890-abcd-ef1234567890',
+      analysisType: 'resume_review',
+      inputSummary: '백엔드 개발자 포트폴리오 분석',
+      result: '',
+      createdAt: '2025-03-20T00:00:00+09:00',
+      fileName: '포트폴리오_김철익.pdf',
+      tags: ['Node.js', 'Python', 'SQL'],
+    },
+    {
+      recordId: 'f9e8d7c6-b5a4-3210-fedc-ba9876543210',
+      analysisType: 'resume_review',
+      inputSummary: '데이터 분석가 역량 진단',
+      result: '',
+      createdAt: '2025-03-10T00:00:00+09:00',
+      fileName: '자기소개서_김철익.pdf',
+      tags: ['Python', 'Pandas'],
+    },
+  ],
+};

--- a/src/types/mypage.ts
+++ b/src/types/mypage.ts
@@ -1,0 +1,18 @@
+export type AnalysisRecord = {
+  recordId: string;
+  analysisType: string;
+  inputSummary: string;
+  result: string;
+  createdAt: string;
+  /** API 확장 전 UI용 (선택) */
+  fileName?: string;
+  tags?: string[];
+};
+
+export type MyPageResponse = {
+  nickname: string;
+  email: string;
+  joinedAt: string;
+  analysisCount: number;
+  analysisRecords: AnalysisRecord[];
+};


### PR DESCRIPTION
Summary
마이페이지
/mypage placeholder를 제거하고, 시안 기준 마이페이지 UI를 구현했습니다.
GET /api/users/me 로 프로필·AI 분석 기록을 조회합니다.
전역 AppLayout의 NAV(마이페이지·로그아웃)를 사용하고, 페이지 중복 헤더는 제거했습니다.
좌측 프로필 카드, 우측 AI 분석 기록(총 N건), 카드별 결과 보기 → /result/:recordId 를 연결했습니다.



항목 | 내용
-- | --
Method / Path | GET /api/users/me
인증 | Authorization: Bearer {accessToken} (기존 api axios 인터셉터)
호출 위치 | src/apis/userApi.ts → fetchMyPage()
사용 화면 | src/pages/mypage/index.tsx (마운트 시 1회, 실패 시 재시도 버튼)

</div></div></div><!--EndFragment-->
</body>
</html>API 연동
사용 API
항목	내용
Method / Path
GET /api/users/me
인증
Authorization: Bearer {accessToken} (기존 api axios 인터셉터)
호출 위치
src/apis/userApi.ts → fetchMyPage()
사용 화면
src/pages/mypage/index.tsx (마운트 시 1회, 실패 시 재시도 버튼)

Response 를 기준으로 매핑
{
  "nickname": "김철익",
  "email": "chulick.kim@kakao.com",
  "joinedAt": "2025-03-15T00:00:00+09:00",
  "analysisCount": 3,
  "analysisRecords": [
    {
      "recordId": "8e2fd5b6-1bb6-4e21-9c48-1d22b7b50c2d",
      "analysisType": "resume_review",
      "inputSummary": "프론트엔드 개발자 이력서 분석",
      "result": "AI 분석 결과 전문",
      "createdAt": "2025-03-28T00:00:00+09:00"
    }
  ]
}


api 변경에 따른 변경 예정 
로컬이 안돌아가서 확인용 현재까지의 PR 작성