### PR TITLE
feat(FO_13): 프로필 설정 preferences API 연동

### DIFF
--- a/src/apis/profileApi.ts
+++ b/src/apis/profileApi.ts
@@ -1,0 +1,15 @@
+import { api } from './api';
+import type {
+  SaveUserPreferencesRequest,
+  SaveUserPreferencesResponse,
+} from '../types/profile';
+
+export async function saveUserPreferences(
+  payload: SaveUserPreferencesRequest
+): Promise<SaveUserPreferencesResponse> {
+  const { data } = await api.post<SaveUserPreferencesResponse>(
+    '/api/users/me/preferences',
+    payload
+  );
+  return data;
+}

--- a/src/pages/profile-setup/index.tsx
+++ b/src/pages/profile-setup/index.tsx
@@ -1,5 +1,9 @@
-import { useEffect, useMemo, useRef, useState } from 'react';
+import { isAxiosError } from 'axios';
+import { useCallback, useEffect, useMemo, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
+import { saveUserPreferences } from '../../apis/profileApi';
 import NextPlanLogo from '../../components/brand/NextPlanLogo';
+import Toast from '../../components/Toast';
 
 const JOB_OPTIONS = [
   'Frontend',
@@ -123,10 +127,42 @@ function ChevronDownIcon({ className = '' }: { className?: string }) {
   );
 }
 
+function getSubmitErrorMessage(error: unknown): string {
+  if (isAxiosError(error)) {
+    const data = error.response?.data;
+    if (data && typeof data === 'object' && 'message' in data && typeof data.message === 'string') {
+      return data.message;
+    }
+    if (error.response?.status === 401) {
+      return '로그인이 필요합니다. 카카오 로그인 후 다시 시도해주세요.';
+    }
+  }
+  return '프로필 저장에 실패했습니다. 잠시 후 다시 시도해주세요.';
+}
+
 export default function ProfileSetupPage() {
+  const navigate = useNavigate();
   const [jobRole, setJobRole] = useState<string>(JOB_OPTIONS[0]);
   const [jobDropdownOpen, setJobDropdownOpen] = useState(false);
   const jobSelectRef = useRef<HTMLDivElement>(null);
+  const [isSubmitting, setIsSubmitting] = useState(false);
+  const [toast, setToast] = useState({
+    show: false,
+    title: '',
+    description: '',
+    type: 'warning' as 'warning' | 'success' | 'info',
+  });
+
+  const closeToast = useCallback(() => {
+    setToast((prev) => ({ ...prev, show: false }));
+  }, []);
+
+  const showToast = useCallback(
+    (title: string, description: string, type: 'warning' | 'success' | 'info' = 'warning') => {
+      setToast({ show: true, title, description, type });
+    },
+    []
+  );
 
   useEffect(() => {
     if (!jobDropdownOpen) return;
@@ -139,13 +175,10 @@ export default function ProfileSetupPage() {
     return () => document.removeEventListener('mousedown', close);
   }, [jobDropdownOpen]);
 
-  const [selectedStacks, setSelectedStacks] = useState<string[]>([
-    'React',
-    'TypeScript',
-    'Next.js',
-    'Python',
-  ]);
+  const [selectedStacks, setSelectedStacks] = useState<string[]>([]);
   const [stackQuery, setStackQuery] = useState('');
+
+  const canSubmit = selectedStacks.length >= 1 && !isSubmitting;
 
   const selectedSet = useMemo(() => new Set(selectedStacks), [selectedStacks]);
 
@@ -168,6 +201,30 @@ export default function ProfileSetupPage() {
 
   const removeStack = (name: string) => {
     setSelectedStacks((prev) => prev.filter((s) => s !== name));
+  };
+
+  const handleComplete = async () => {
+    if (!canSubmit) {
+      showToast('입력을 확인해주세요', '희망 직군과 기술 스택을 1개 이상 선택해주세요.');
+      return;
+    }
+
+    setIsSubmitting(true);
+    try {
+      await saveUserPreferences({
+        desiredJobRole: jobRole,
+        techStacks: selectedStacks,
+      });
+      navigate('/', { replace: true });
+    } catch (error) {
+      showToast('저장 실패', getSubmitErrorMessage(error));
+    } finally {
+      setIsSubmitting(false);
+    }
+  };
+
+  const handleSkipLater = () => {
+    navigate('/', { replace: true });
   };
 
   return (
@@ -381,18 +438,31 @@ export default function ProfileSetupPage() {
 
           <button
             type="button"
-            className="mt-10 w-full rounded-full bg-orange-500 py-3.5 text-sm font-bold text-white shadow-lg shadow-orange-500/25 transition-colors hover:bg-orange-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-500"
+            disabled={!canSubmit}
+            onClick={handleComplete}
+            className="mt-10 w-full rounded-full bg-orange-500 py-3.5 text-sm font-bold text-white shadow-lg shadow-orange-500/25 transition-colors hover:bg-orange-600 focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-orange-500 disabled:cursor-not-allowed disabled:opacity-50"
           >
-            완료
+            {isSubmitting ? '저장 중…' : '완료'}
           </button>
           <button
             type="button"
-            className="mt-4 w-full text-center text-sm font-medium text-zinc-500 underline-offset-2 hover:text-zinc-700 hover:underline"
+            disabled={isSubmitting}
+            onClick={handleSkipLater}
+            className="mt-4 w-full text-center text-sm font-medium text-zinc-500 underline-offset-2 hover:text-zinc-700 hover:underline disabled:cursor-not-allowed disabled:opacity-50"
           >
             나중에 설정하기
           </button>
         </div>
       </div>
+
+      <Toast
+        show={toast.show}
+        onClose={closeToast}
+        title={toast.title}
+        description={toast.description}
+        type={toast.type}
+        icon={toast.type === 'success' ? '✓' : '⚠️'}
+      />
     </div>
   );
 }

--- a/src/types/profile.ts
+++ b/src/types/profile.ts
@@ -1,0 +1,8 @@
+export interface SaveUserPreferencesRequest {
+  desiredJobRole: string;
+  techStacks: string[];
+}
+
+export interface SaveUserPreferencesResponse {
+  message: string;
+}


### PR DESCRIPTION
## Summary

- 프로필 설정(`/profile-setup`) **완료** 시 `POST /api/users/me/preferences` 호출
- 희망 직군(`desiredJobRole`) + 기술 스택(`techStacks`, 1~15개) 저장
- 저장 성공 시 메인(`/`)으로 이동
- 팀에서 보고된 **「희망 직군이 DB에 없어 API 에러」** 해소를 위한 프론트 연동

## 변경 사항

| 파일 | 내용 |
|------|------|
| `src/apis/profileApi.ts` | `saveUserPreferences()` 추가 |
| `src/types/profile.ts` | 요청/응답 타입 |
| `src/pages/profile-setup/index.tsx` | 완료 버튼 API 연동, 유효성, 로딩/에러 Toast |

## API 매핑

| 항목 | 값 |
|------|-----|
| Method | `POST` |
| Path | `/api/users/me/preferences` |
| Body | `{ "desiredJobRole": string, "techStacks": string[] }` |
| 성공 | `200` + `{ "message": "success" }` |
| 인증 | Bearer `accessToken` (기존 `api` 인터셉터) |

## UI 동작

- **완료**: 직군 선택 + 스택 **1개 이상**일 때만 활성 → 저장 후 `/` 이동
- **나중에 설정하기**: API 호출 없이 `/` 이동 (DB 미저장 — 의도된 동작)
- 제출 중 버튼 비활성 + 「저장 중…」 표시
- 실패 시 Toast (401, 400 등)

### 로컬 / 배포 공통

- [ ] 카카오 로그인 후 `accessToken` 존재 확인
- [ ] `/profile-setup` 접속
- [ ] 희망 직군 선택 + 기술 스택 1개 이상 추가
- [ ] **완료** 클릭 → Network `POST /api/users/me/preferences` **200**
- [ ] 메인(`/`)으로 이동
- [ ] 스택 0개일 때 **완료** 비활성
- [ ] **나중에 설정하기** → 저장 API 없이 `/` 이동

### 에러 케이스

- [ ] 미로그인 상태에서 완료 → 401 Toast
- [ ] 네트워크/서버 오류 시 Toast 메시지 표시