### PR TITLE
feat(FO_15): 인증 동선 마무리 (콜백 분기·라우트 가드·더미 토큰 제거)

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -28,7 +28,10 @@ function App() {
       <Routes>
         {/* 전역 헤더 없음 */}
         <Route path="/auth/kakao/callback" element={<KakaoCallback />} />
-        <Route path="/profile-setup" element={<ProfileSetupPage />} />
+
+        <Route element={<ProtectedRoute isAuthenticated={isLoggedIn} />}>
+          <Route path="/profile-setup" element={<ProfileSetupPage />} />
+        </Route>
 
         <Route element={<AppLayout />}>
           <Route path="/" element={<MainPage />} />

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,4 +1,5 @@
 import axios, { AxiosError, type AxiosResponse, type InternalAxiosRequestConfig } from 'axios';
+import { useAuthStore } from '../store/authStore';
 
 // 무한 루프 방지를 위한 커스텀 타입
 interface CustomConfig extends InternalAxiosRequestConfig {
@@ -52,8 +53,12 @@ api.interceptors.response.use(
         return api(originalRequest);
 
       } catch (refreshError) {
-        localStorage.removeItem('accessToken');
-        window.location.href = '/login'; 
+        try {
+          useAuthStore.getState().logout();
+        } catch {
+          localStorage.removeItem('accessToken');
+        }
+        window.location.href = '/login';
         return Promise.reject(refreshError);
       }
     }

--- a/src/pages/kakao/KakaoCallback.tsx
+++ b/src/pages/kakao/KakaoCallback.tsx
@@ -1,47 +1,62 @@
-import { useEffect, useState } from 'react';
-import { useAuthStore } from '../../store/authStore';
+import { useEffect, useRef, useState } from 'react';
+import { useNavigate } from 'react-router-dom';
 import { api } from '../../apis/api';
-import Toast from '../../components/Toast'; 
-import { useNavigate } from 'react-router-dom'
+import { fetchMyPage } from '../../apis/userApi';
+import Toast from '../../components/Toast';
+import { useAuthStore } from '../../store/authStore';
 
 export default function KakaoCallback() {
   const { login } = useAuthStore();
-  const [toast, setToast] = useState({
+  const navigate = useNavigate();
+  const handledRef = useRef(false);
+
+  const [toast, setToast] = useState<{
+    show: boolean;
+    title: string;
+    description?: string;
+  }>({
     show: false,
     title: '',
   });
 
   const closeToast = () => setToast((prev) => ({ ...prev, show: false }));
-  const navigate = useNavigate();
 
   useEffect(() => {
+    if (handledRef.current) return;
+    handledRef.current = true;
+
     const code = new URL(window.location.href).searchParams.get('code');
-
-    if (code) {
-      api.post('/api/auth/kakao/login', { code })
-        .then(res => {
-          const { accessToken } = res.data;
-          login(accessToken);
-
-          navigate('/', { replace: true });
-        })
-        .catch((err) => {
-          console.error("카카오 로그인 API 요청 실패: ", err);
-
-          setToast({
-            show: true,
-            title: '곧 로그인이 완료됩니다.',
-          });
-
-          const dummyToken = 'kakao-temp-token-12345';
-          login(dummyToken);
-          
-          setTimeout(() => {
-            navigate('/', { replace: true });
-          }, 1000);
-        });
+    if (!code) {
+      navigate('/', { replace: true });
+      return;
     }
-  }, [login]);
+
+    (async () => {
+      try {
+        const res = await api.post('/api/auth/kakao/login', { code });
+        const { accessToken } = res.data;
+        login(accessToken);
+      } catch (err) {
+        console.error('카카오 로그인 API 요청 실패: ', err);
+        setToast({
+          show: true,
+          title: '로그인에 실패했습니다',
+          description: '잠시 후 다시 시도해 주세요.',
+        });
+        setTimeout(() => navigate('/login', { replace: true }), 1500);
+        return;
+      }
+
+      try {
+        const me = await fetchMyPage();
+        const onboarded = Boolean(me?.desiredJobRole);
+        navigate(onboarded ? '/' : '/profile-setup', { replace: true });
+      } catch (err) {
+        console.error('프로필 조회 실패, 메인으로 이동: ', err);
+        navigate('/', { replace: true });
+      }
+    })();
+  }, [login, navigate]);
 
   return (
     <div className="min-h-screen flex items-center justify-center bg-zinc-950 text-white">
@@ -53,11 +68,12 @@ export default function KakaoCallback() {
         </div>
       </div>
 
-      <Toast 
-        show={toast.show} 
-        onClose={closeToast} 
-        title={toast.title} 
-        type="warning" 
+      <Toast
+        show={toast.show}
+        onClose={closeToast}
+        title={toast.title}
+        description={toast.description}
+        type="warning"
         icon="⚠️"
       />
     </div>


### PR DESCRIPTION
## Summary

- 카카오 콜백에서 `GET /api/users/me`로 온보딩 분기 (`desiredJobRole` 유무)
- 카카오 로그인 실패 시 더미 토큰 발급 제거 → Toast + `/login`
- `/profile-setup`을 `ProtectedRoute` 하위로 이동
- 401 → reissue 실패 시 `authStore.logout()` 호출

## 변경 파일

- `src/pages/kakao/KakaoCallback.tsx`
- `src/App.tsx`
- `src/apis/api.ts`

## Test plan

- [ ] 신규 사용자: 로그인 → `/profile-setup`
- [ ] 기존 사용자: 로그인 → `/`
- [ ] 비로그인 `/profile-setup` → `/login`
- [ ] 카카오 로그인 실패 시 더미 토큰 없음 확인
- [ ] 만료 토큰 재발급 실패 시 로그아웃 + `/login`

Closes #15