### PR TITLE
feat(FO_16): 메인 NAV 통합 (대외활동·공모전 헤더 이동, hero 버튼 제거)

### DIFF
--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -2,17 +2,34 @@ import type { ReactNode } from 'react';
 import NextPlanLogo from '../brand/NextPlanLogo';
 
 type AppHeaderProps = {
-  /** 메인 등 페이지별 오른쪽 액션 (예: KakaoLoginButton) */
+  /** 가운데 NAV (메인 페이지 등에서만 사용) */
+  centerSlot?: ReactNode;
+  /** 페이지별 오른쪽 액션 (예: KakaoLoginButton) */
   rightSlot?: ReactNode;
 };
 
-export default function AppHeader({ rightSlot }: AppHeaderProps) {
+export default function AppHeader({ centerSlot, rightSlot }: AppHeaderProps) {
   return (
     <header className="sticky top-0 z-50 w-full border-b border-zinc-100 bg-white">
-      <div className="mx-auto flex h-14 max-w-6xl items-center justify-between px-4 sm:h-16 sm:px-6">
-        <NextPlanLogo />
+      <div className="mx-auto flex h-14 max-w-6xl items-center gap-4 px-4 sm:h-16 sm:px-6">
+        <div className="flex flex-1 items-center justify-start">
+          <NextPlanLogo />
+        </div>
+
+        {centerSlot ? (
+          <nav
+            className="hidden flex-1 items-center justify-center sm:flex"
+            aria-label="주요 메뉴"
+          >
+            {centerSlot}
+          </nav>
+        ) : null}
+
         {rightSlot ? (
-          <nav className="flex items-center gap-2 sm:gap-3" aria-label="계정">
+          <nav
+            className="flex flex-1 items-center justify-end gap-2 sm:gap-3"
+            aria-label="계정"
+          >
             {rightSlot}
           </nav>
         ) : null}

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,12 +1,19 @@
-import { Outlet } from 'react-router-dom';
+import { Outlet, useLocation } from 'react-router-dom';
 import AppHeader from './AppHeader';
+import MainNav from './MainNav';
 import KakaoLoginButton from '../../pages/kakao/component/KakaoLoginButton';
 
 /** 전역 NAV: AppHeader + 페이지 본문(Outlet) */
 export default function AppLayout() {
+  const { pathname } = useLocation();
+  const isMainPage = pathname === '/' || pathname === '/main';
+
   return (
     <>
-      <AppHeader rightSlot={<KakaoLoginButton />} />
+      <AppHeader
+        centerSlot={isMainPage ? <MainNav /> : undefined}
+        rightSlot={<KakaoLoginButton />}
+      />
       <Outlet />
     </>
   );

--- a/src/components/layout/MainNav.tsx
+++ b/src/components/layout/MainNav.tsx
@@ -1,0 +1,30 @@
+import { NavLink } from 'react-router-dom';
+
+const NAV_ITEMS = [
+  { label: '대외활동', to: '/board/activities' },
+  { label: '공모전', to: '/board/competitions' },
+] as const;
+
+export default function MainNav() {
+  return (
+    <ul className="flex items-center gap-6 sm:gap-8">
+      {NAV_ITEMS.map((item) => (
+        <li key={item.to}>
+          <NavLink
+            to={item.to}
+            className={({ isActive }) =>
+              [
+                'text-sm transition-colors sm:text-base',
+                isActive
+                  ? 'font-bold text-orange-500'
+                  : 'font-medium text-zinc-700 hover:text-zinc-900',
+              ].join(' ')
+            }
+          >
+            {item.label}
+          </NavLink>
+        </li>
+      ))}
+    </ul>
+  );
+}

--- a/src/pages/main/index.tsx
+++ b/src/pages/main/index.tsx
@@ -1,9 +1,6 @@
 import { motion, type Variants } from 'framer-motion';
-import { useNavigate } from 'react-router-dom';
 import FileUpload from "./component/FileUpload";
 export default function MainPage() {
-  const navigate = useNavigate();
-
   // 공통 텍스트 애니메이션
   const fadeUpItem: Variants = {
     hidden: { opacity: 0, y: 30 },
@@ -54,29 +51,6 @@ export default function MainPage() {
           <span className="text-orange-500">AI 역량 분석</span>
         </motion.h1>
 
-        {/* 새롭게 추가된 버튼 그룹 영역 */}
-        <motion.div
-          variants={fadeUpItem}
-          initial="hidden"
-          whileInView="visible"
-          viewport={{ once: false, amount: 0.5 }}
-          className="flex flex-wrap justify-center gap-4 mb-12 relative z-10"
-        >
-
-          <button 
-            onClick={() => navigate('/board/activities')}
-            className="px-6 py-3 bg-orange-500 text-white rounded-xl hover:bg-orange-600 transition-colors text-sm font-bold shadow-lg shadow-orange-500/20"
-          >
-            대외활동 보기
-          </button>
-          <button 
-            onClick={() => navigate('/board/competitions')}
-            className="px-6 py-3 bg-orange-500 text-white rounded-xl hover:bg-orange-600 transition-colors text-sm font-bold shadow-lg shadow-orange-500/20"
-          >
-            공모전 보기
-          </button>
-        </motion.div>
-        
         <motion.p
           variants={fadeUpItem}
           initial="hidden"


### PR DESCRIPTION
## Summary

- 메인(`/`, `/main`) 헤더에만 **대외활동 / 공모전** NAV 노출
- 메인 hero 본문의 기존 두 버튼 제거 (NAV로 통합)
- 다른 페이지는 기존처럼 우측 액션만 유지

## 변경 파일

- `src/components/layout/MainNav.tsx` (신규)
- `src/components/layout/AppHeader.tsx`
- `src/components/layout/AppLayout.tsx`
- `src/pages/main/index.tsx`

## Test plan

- [ ] `/` 헤더에 대외활동·공모전 NAV 노출, hero 본문 버튼 없음
- [ ] `/mypage`, `/board/*`, `/login`에는 NAV 없음
- [ ] NAV 클릭 시 각 카테고리로 정상 이동
- [ ] 모바일(<sm)에서 헤더 깨지지 않음
- [ ] `pnpm build` 통과
