### PR TITLE
feat(FO_18): 로그인 페이지 시안 반영 및 인증 동선 정리

### DIFF
--- a/src/App.tsx
+++ b/src/App.tsx
@@ -10,10 +10,8 @@ import ResultPage from './pages/result/index';
 import BoardPage from './pages/board/BoardPage';
 import BoardDetailPage from './pages/board/BoardDetailPage';
 import MyPage from './pages/mypage';
+import LoginPage from './pages/login';
 
-
-// 임시 페이지 컴포넌트들
-const Login = () => <div className="p-20 text-center">🔑 로그인 페이지</div>;
 function App() {
   // Zustand 스토어에서 로그인 상태와 상태 검사 함수 꺼내오기
   const { isLoggedIn, checkAuth } = useAuthStore();
@@ -28,6 +26,7 @@ function App() {
       <Routes>
         {/* 전역 헤더 없음 */}
         <Route path="/auth/kakao/callback" element={<KakaoCallback />} />
+        <Route path="/login" element={<LoginPage />} />
 
         <Route element={<ProtectedRoute isAuthenticated={isLoggedIn} />}>
           <Route path="/profile-setup" element={<ProfileSetupPage />} />
@@ -36,7 +35,6 @@ function App() {
         <Route element={<AppLayout />}>
           <Route path="/" element={<MainPage />} />
           <Route path="/main" element={<MainPage />} />
-          <Route path="/login" element={<Login />} />
           <Route path="/board/:category" element={<BoardPage />} />
           <Route path="/board/:category/:id" element={<BoardDetailPage />} />
 

--- a/src/apis/api.ts
+++ b/src/apis/api.ts
@@ -1,5 +1,6 @@
 import axios, { AxiosError, type AxiosResponse, type InternalAxiosRequestConfig } from 'axios';
 import { useAuthStore } from '../store/authStore';
+import { savePostLoginRedirect } from '../utils/postLoginRedirect';
 
 // 무한 루프 방지를 위한 커스텀 타입
 interface CustomConfig extends InternalAxiosRequestConfig {
@@ -57,7 +58,10 @@ api.interceptors.response.use(
         } catch {
           localStorage.removeItem('accessToken');
         }
-        window.location.href = '/login';
+        savePostLoginRedirect(
+          `${window.location.pathname}${window.location.search}`
+        );
+        window.location.href = '/login?reason=session_expired';
         return Promise.reject(refreshError);
       }
     }

--- a/src/components/ProtectedRoute.tsx
+++ b/src/components/ProtectedRoute.tsx
@@ -1,16 +1,24 @@
-import { Navigate, Outlet } from 'react-router-dom';
+import { Navigate, Outlet, useLocation } from 'react-router-dom';
+import { savePostLoginRedirect } from '../utils/postLoginRedirect';
 
 interface ProtectedRouteProps {
-  isAuthenticated: boolean; // 로그인 여부
-  redirectPath?: string;    // 로그인 안 했을 때 보낼 경로
+  isAuthenticated: boolean;
+  redirectPath?: string;
 }
 
-const ProtectedRoute = ({ 
-  isAuthenticated, 
-  redirectPath = '/login' 
+const ProtectedRoute = ({
+  isAuthenticated,
+  redirectPath = '/login',
 }: ProtectedRouteProps) => {
+  const location = useLocation();
+
   if (!isAuthenticated) {
-    return <Navigate to={redirectPath} replace />;
+    const returnPath = `${location.pathname}${location.search}`;
+    savePostLoginRedirect(returnPath);
+
+    return (
+      <Navigate to={redirectPath} replace state={{ from: location }} />
+    );
   }
 
   return <Outlet />;

--- a/src/pages/kakao/KakaoCallback.tsx
+++ b/src/pages/kakao/KakaoCallback.tsx
@@ -4,6 +4,7 @@ import { api } from '../../apis/api';
 import { fetchMyPage } from '../../apis/userApi';
 import Toast from '../../components/Toast';
 import { useAuthStore } from '../../store/authStore';
+import { consumePostLoginRedirect } from '../../utils/postLoginRedirect';
 
 export default function KakaoCallback() {
   const { login } = useAuthStore();
@@ -38,19 +39,21 @@ export default function KakaoCallback() {
         login(accessToken);
       } catch (err) {
         console.error('카카오 로그인 API 요청 실패: ', err);
-        setToast({
-          show: true,
-          title: '로그인에 실패했습니다',
-          description: '잠시 후 다시 시도해 주세요.',
-        });
-        setTimeout(() => navigate('/login', { replace: true }), 1500);
+        navigate('/login', { replace: true, state: { loginError: true } });
         return;
       }
 
       try {
         const me = await fetchMyPage();
         const onboarded = Boolean(me?.desiredJobRole);
-        navigate(onboarded ? '/' : '/profile-setup', { replace: true });
+
+        if (!onboarded) {
+          navigate('/profile-setup', { replace: true });
+          return;
+        }
+
+        const returnPath = consumePostLoginRedirect();
+        navigate(returnPath ?? '/', { replace: true });
       } catch (err) {
         console.error('프로필 조회 실패, 메인으로 이동: ', err);
         navigate('/', { replace: true });

--- a/src/pages/kakao/component/KakaoLoginButton.tsx
+++ b/src/pages/kakao/component/KakaoLoginButton.tsx
@@ -1,17 +1,9 @@
 import { Button } from '../../../components/ui/Button';
 import { useAuthStore } from '../../../store/authStore';
+import { startKakaoLogin } from '../../../utils/kakaoAuth';
 
 export default function KakaoLoginButton() {
   const { isLoggedIn, logout } = useAuthStore();
-
-  const handleKakaoLogin = () => {
-    const REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
-    const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
-    
-    const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
-
-    window.location.href = KAKAO_AUTH_URL;
-  };
 
   if (isLoggedIn) {
     return (
@@ -28,8 +20,9 @@ export default function KakaoLoginButton() {
 
   // 비로그인 상태일 때: 기존 카카오 로그인 버튼 보여주기
   return (
-    <button 
-      onClick={handleKakaoLogin}
+    <button
+      type="button"
+      onClick={startKakaoLogin}
       className="flex items-center gap-2 bg-[#FEE500] hover:bg-[#FDD800] text-[#000000] px-5 py-2.5 rounded-full font-bold text-sm transition-colors shadow-lg shadow-black/10"
     >
       <svg className="w-4 h-4 fill-current" viewBox="0 0 24 24" xmlns="http://www.w3.org/2000/svg">

--- a/src/pages/login/index.tsx
+++ b/src/pages/login/index.tsx
@@ -1,0 +1,105 @@
+import { useEffect, useMemo } from 'react';
+import { useLocation, useNavigate, useSearchParams } from 'react-router-dom';
+import NextPlanLogo from '../../components/brand/NextPlanLogo';
+import { useAuthStore } from '../../store/authStore';
+import { startKakaoLogin } from '../../utils/kakaoAuth';
+import {
+  consumePostLoginRedirect,
+  savePostLoginRedirect,
+} from '../../utils/postLoginRedirect';
+
+type LoginLocationState = {
+  from?: { pathname: string; search?: string };
+  loginError?: boolean;
+};
+
+function KakaoIcon() {
+  return (
+    <svg className="h-5 w-5 shrink-0 fill-current" viewBox="0 0 24 24" aria-hidden>
+      <path d="M12 3c-5.523 0-10 3.535-10 7.896 0 2.825 1.848 5.305 4.675 6.643l-1.196 4.394c-.086.315.265.556.53.376l5.127-3.41c.28.02.565.032.854.032 5.523 0 10-3.535 10-7.896C22 6.535 17.523 3 12 3z" />
+    </svg>
+  );
+}
+
+export default function LoginPage() {
+  const { isLoggedIn } = useAuthStore();
+  const navigate = useNavigate();
+  const location = useLocation();
+  const [searchParams] = useSearchParams();
+
+  const locationState = location.state as LoginLocationState | null;
+
+  const bannerMessage = useMemo(() => {
+    if (searchParams.get('reason') === 'session_expired') {
+      return '로그인이 만료되었습니다. 다시 로그인해 주세요.';
+    }
+    if (locationState?.loginError) {
+      return '로그인에 실패했습니다. 잠시 후 다시 시도해 주세요.';
+    }
+    if (locationState?.from) {
+      return '로그인이 필요합니다. 로그인 후 이어서 이용할 수 있습니다.';
+    }
+    return null;
+  }, [searchParams, locationState]);
+
+  useEffect(() => {
+    const from = locationState?.from;
+    if (from?.pathname) {
+      savePostLoginRedirect(`${from.pathname}${from.search ?? ''}`);
+    }
+  }, [locationState?.from]);
+
+  useEffect(() => {
+    if (!isLoggedIn) return;
+    const saved = consumePostLoginRedirect();
+    navigate(saved ?? '/', { replace: true });
+  }, [isLoggedIn, navigate]);
+
+  return (
+    <div className="flex min-h-screen flex-col items-center justify-center bg-zinc-100 px-4 py-12">
+      <div className="mb-8">
+        <NextPlanLogo className="text-2xl sm:text-3xl" />
+      </div>
+
+      <div className="w-full max-w-md rounded-3xl border border-zinc-100 bg-white px-8 py-10 shadow-sm shadow-zinc-900/5 sm:px-10 sm:py-12">
+        <div className="text-center">
+          <h1 className="text-2xl font-bold text-zinc-900">로그인</h1>
+          <p className="mt-2 text-sm text-zinc-500">
+            AI 역량 분석 서비스에 오신 것을 환영합니다
+          </p>
+        </div>
+
+        {bannerMessage && (
+          <p
+            className="mt-6 rounded-xl border border-orange-100 bg-orange-50 px-4 py-3 text-center text-sm text-orange-800"
+            role="status"
+          >
+            {bannerMessage}
+          </p>
+        )}
+
+        <button
+          type="button"
+          onClick={startKakaoLogin}
+          className="mt-8 flex w-full items-center justify-center gap-2 rounded-full bg-[#FEE500] px-6 py-3.5 text-sm font-bold text-zinc-900 transition-colors hover:bg-[#FDD800] focus-visible:outline focus-visible:outline-2 focus-visible:outline-offset-2 focus-visible:outline-[#FEE500]"
+        >
+          <KakaoIcon />
+          카카오로 시작하기
+        </button>
+
+        <div className="relative my-8">
+          <div className="absolute inset-0 flex items-center" aria-hidden>
+            <div className="w-full border-t border-zinc-200" />
+          </div>
+          <div className="relative flex justify-center text-xs uppercase tracking-wide">
+            <span className="bg-white px-3 text-zinc-400">OR</span>
+          </div>
+        </div>
+
+        <p className="text-center text-xs leading-relaxed text-zinc-400">
+          계속 진행하면 이용약관 및 개인정보처리방침에 동의하게 됩니다
+        </p>
+      </div>
+    </div>
+  );
+}

--- a/src/utils/kakaoAuth.ts
+++ b/src/utils/kakaoAuth.ts
@@ -1,0 +1,9 @@
+/** 카카오 OAuth 인증 페이지로 이동 */
+export function startKakaoLogin(): void {
+  const REST_API_KEY = import.meta.env.VITE_KAKAO_REST_API_KEY;
+  const REDIRECT_URI = import.meta.env.VITE_KAKAO_REDIRECT_URI;
+
+  const KAKAO_AUTH_URL = `https://kauth.kakao.com/oauth/authorize?client_id=${REST_API_KEY}&redirect_uri=${REDIRECT_URI}&response_type=code`;
+
+  window.location.href = KAKAO_AUTH_URL;
+}

--- a/src/utils/postLoginRedirect.ts
+++ b/src/utils/postLoginRedirect.ts
@@ -1,0 +1,28 @@
+const STORAGE_KEY = 'postLoginRedirect';
+
+function isSafeRedirectPath(path: string): boolean {
+  return (
+    path.startsWith('/') &&
+    !path.startsWith('//') &&
+    path !== '/login' &&
+    !path.startsWith('/auth/')
+  );
+}
+
+/** 카카오 OAuth 라운드트립 후 복귀할 경로 저장 */
+export function savePostLoginRedirect(path: string): void {
+  if (isSafeRedirectPath(path)) {
+    sessionStorage.setItem(STORAGE_KEY, path);
+  }
+}
+
+export function peekPostLoginRedirect(): string | null {
+  const path = sessionStorage.getItem(STORAGE_KEY);
+  return path && isSafeRedirectPath(path) ? path : null;
+}
+
+export function consumePostLoginRedirect(): string | null {
+  const path = peekPostLoginRedirect();
+  sessionStorage.removeItem(STORAGE_KEY);
+  return path;
+}


### PR DESCRIPTION
- 시안 기반 전용 로그인 페이지 추가 (AppLayout 밖, 헤더 없음)
- ProtectedRoute/401 시 post-login redirect 저장 (sessionStorage + state.from)
- 카카오 로그인 성공 후 저장 경로 복귀, 미온보딩 시 profile-setup 우선
- 401 refresh 실패 시 /login?reason=session_expired 안내 배너
- kakaoAuth/postLoginRedirect 유틸 분리, KakaoLoginButton 공통화

## Summary

플레이스홀더였던 `/login` 페이지를 시안 기반 전용 로그인 화면으로 교체하고,
비로그인·세션 만료·카카오 실패 시 사용자가 명확한 안내와 함께 로그인할 수 있도록 인증 동선을 정리합니다.

- 로그인 후 **원래 가려던 페이지로 복귀** (ProtectedRoute + OAuth 라운드트립 대응)
- `/login`은 **AppLayout 밖** 풀스크린 카드 UI (헤더 중복 제거)

## 배경

기존 `/login`은 `🔑 로그인 페이지` placeholder만 표시되어,
로그아웃 후 `/mypage` 직접 진입 등 ProtectedRoute redirect 시 UX가 어색했습니다.
헤더의 카카오 버튼만으로는 로그인 전용 화면이 없어 시안과 동선이 맞지 않았습니다.

## Changes

| 영역 | 변경 |
|---|---|
| `src/pages/login/index.tsx` | **신규** — 시안 기반 로그인 페이지 (로고, 카드, 카카오 CTA, OR, 약관 문구) |
| `src/App.tsx` | placeholder `Login` 제거, `/login`을 AppLayout **밖**으로 분리 |
| `src/components/ProtectedRoute.tsx` | 비로그인 시 `state.from` + `sessionStorage`에 복귀 경로 저장 |
| `src/pages/kakao/KakaoCallback.tsx` | 성공 시 저장 경로 복귀 / 미온보딩 시 `/profile-setup` / 실패 시 즉시 `/login` |
| `src/apis/api.ts` | 401 refresh 실패 시 경로 저장 후 `/login?reason=session_expired` |
| `src/utils/kakaoAuth.ts` | **신규** — 카카오 OAuth 시작 공통화 |
| `src/utils/postLoginRedirect.ts` | **신규** — post-login redirect 저장·소비 |
| `src/pages/kakao/component/KakaoLoginButton.tsx` | `startKakaoLogin` 유틸 사용 |

## UI (시안 반영)

- [ ] 연한 회색 배경 + 상단 NextPlan 로고
- [ ] 흰색 카드: "로그인" 타이틀 / 환영 문구
- [ ] 노란색 **"카카오로 시작하기"** 버튼 (전체 너비)
- [ ] OR 구분선 + 약관 안내 문구
- [ ] `/login` 진입 시 **전역 헤더 없음** (AppLayout 미적용)

## 안내 배너 (상황별)

| 상황 | 표시 문구 |
|---|---|
| `?reason=session_expired` | 로그인이 만료되었습니다… |
| ProtectedRoute에서 redirect | 로그인이 필요합니다… |
| 카카오 로그인 API 실패 | 로그인에 실패했습니다… |

## Test plan (수동)

### 기본 UI
- [ ] `pnpm build` 통과
- [ ] 로그아웃 상태에서 `/login` 직접 접속 → 시안과 동일한 레이아웃
- [ ] 헤더(대외활동/공모전/마이페이지)가 **보이지 않음**
- [ ] **카카오로 시작하기** 클릭 → 카카오 OAuth 페이지로 이동

### 로그인 후 복귀 (redirect-after-login)
- [ ] 로그아웃 → `/mypage` 접속 → `/login` + 안내 배너
- [ ] 카카오 로그인 성공(온보딩 완료 계정) → **`/mypage`로 복귀**
- [ ] 로그아웃 → `/result/{id}` 접속 → 로그인 → **해당 결과 페이지로 복귀**

### 신규/미온보딩 사용자
- [ ] `desiredJobRole` 없는 계정으로 로그인 → **`/profile-setup`** (저장된 redirect보다 온보딩 우선)
- [ ] 프로필 설정 완료 후 기존 동선(마이페이지 등) 정상

### 세션 만료
- [ ] accessToken 만료 + refresh 실패 상황(또는 수동으로 토큰 삭제 후 API 호출)
- [ ] `/login?reason=session_expired` 이동 + **만료 안내 배너** 표시
- [ ] 재로그인 후 이전 페이지 복귀

### 예외·회귀
- [ ] 카카오 로그인 실패(잘못된 code 등) → `/login` + 실패 배너
- [ ] **이미 로그인** 상태에서 `/login` 접속 → `/` (또는 저장된 경로)로 자동 이동
- [ ] 메인/게시판 등 **헤더 카카오 로그인** 버튼 동작 유지 (회귀 없음)
- [ ] `/auth/kakao/callback` 로딩 UI 정상

## Out of scope

- 이용약관/개인정보처리방침 **링크** 연결 (문구만 표시)
- 메인 hero에 별도 로그인 CTA 추가
- 이메일/비밀번호 로그인

## Related

- FO_15: 카카오 콜백·온보딩 분기
- FO_17: 마이페이지 분석 기록 카드 (main 머지 완료)
- Refs #18 