### PR TITLE
[Fo 19] 마이페이지 분석 기록 삭제 기능 연동

### DIFF
--- a/src/apis/userApi.ts
+++ b/src/apis/userApi.ts
@@ -5,3 +5,16 @@ export async function fetchMyPage(): Promise<MyPageResponse> {
   const { data } = await api.get<MyPageResponse>('/api/users/me');
   return data;
 }
+
+export type DeleteAnalysisResultResponse = {
+  message: string;
+};
+
+export async function deleteAnalysisResult(
+  analysisId: string
+): Promise<DeleteAnalysisResultResponse> {
+  const { data } = await api.delete<DeleteAnalysisResultResponse>(
+    `/api/analyze/result/${analysisId}`
+  );
+  return data;
+}

--- a/src/pages/mypage/components/AnalysisHistoryCard.tsx
+++ b/src/pages/mypage/components/AnalysisHistoryCard.tsx
@@ -10,9 +10,15 @@ const TAG_STYLES = [
 
 type AnalysisHistoryCardProps = {
   record: AnalysisRecord;
+  onDelete: (recordId: string) => void;
+  isDeleting: boolean;
 };
 
-export default function AnalysisHistoryCard({ record }: AnalysisHistoryCardProps) {
+export default function AnalysisHistoryCard({
+  record,
+  onDelete,
+  isDeleting,
+}: AnalysisHistoryCardProps) {
   const metaParts = [formatKoreanDate(record.createdAt)];
   if (record.fileName) metaParts.push(record.fileName);
 
@@ -34,9 +40,19 @@ export default function AnalysisHistoryCard({ record }: AnalysisHistoryCardProps
           </ul>
         )}
       </div>
-      <Button variant="secondary" to={`/result/${record.recordId}`} className="shrink-0 self-start sm:self-center">
-        결과 보기
-      </Button>
+      <div className="flex shrink-0 gap-2 self-start sm:self-center">
+        <Button variant="secondary" to={`/result/${record.recordId}`}>
+          결과 보기
+        </Button>
+        <Button
+          variant="secondary"
+          onClick={() => onDelete(record.recordId)}
+          disabled={isDeleting}
+          className="border-red-200 text-red-700 hover:bg-red-50"
+        >
+          {isDeleting ? '삭제 중...' : '삭제'}
+        </Button>
+      </div>
     </article>
   );
 }

--- a/src/pages/mypage/index.tsx
+++ b/src/pages/mypage/index.tsx
@@ -1,6 +1,11 @@
+import { isAxiosError } from 'axios';
 import { useCallback, useEffect, useState } from 'react';
-import { fetchMyPage } from '../../apis/userApi';
+import {
+  deleteAnalysisResult,
+  fetchMyPage,
+} from '../../apis/userApi';
 import { Button } from '../../components/ui/Button';
+import Toast from '../../components/Toast';
 import type { MyPageResponse } from '../../types/mypage';
 import AnalysisHistoryCard from './components/AnalysisHistoryCard';
 import ProfileCard from './components/ProfileCard';
@@ -10,6 +15,19 @@ export default function MyPage() {
   const [data, setData] = useState<MyPageResponse | null>(null);
   const [loading, setLoading] = useState(true);
   const [error, setError] = useState<string | null>(null);
+  const [deletingRecordId, setDeletingRecordId] = useState<string | null>(null);
+  const [toast, setToast] = useState<{
+    show: boolean;
+    title: string;
+    description?: string;
+    type?: 'warning' | 'success' | 'info';
+    icon?: string;
+  }>({
+    show: false,
+    title: '',
+  });
+
+  const closeToast = () => setToast((prev) => ({ ...prev, show: false }));
 
   const load = useCallback(async () => {
     setLoading(true);
@@ -32,6 +50,68 @@ export default function MyPage() {
   useEffect(() => {
     void load();
   }, [load]);
+
+  const getDeleteErrorMessage = (error: unknown) => {
+    if (!isAxiosError(error)) {
+      return '삭제 처리 중 오류가 발생했습니다. 잠시 후 다시 시도해 주세요.';
+    }
+
+    const status = error.response?.status;
+    if (status === 401) {
+      return '로그인이 만료되었습니다. 다시 로그인해 주세요.';
+    }
+    if (status === 403) {
+      return '본인 분석 기록만 삭제할 수 있습니다.';
+    }
+    if (status === 404) {
+      return '이미 삭제되었거나 존재하지 않는 분석 기록입니다.';
+    }
+    return '분석 기록 삭제에 실패했습니다. 잠시 후 다시 시도해 주세요.';
+  };
+
+  const handleDeleteRecord = useCallback(
+    async (recordId: string) => {
+      if (deletingRecordId) return;
+
+      const confirmed = window.confirm(
+        '분석 기록을 삭제하시겠어요?\n삭제한 기록은 복구할 수 없습니다.'
+      );
+      if (!confirmed) return;
+
+      setDeletingRecordId(recordId);
+      try {
+        await deleteAnalysisResult(recordId);
+        setData((prev) => {
+          if (!prev) return prev;
+          const nextRecords = prev.analysisRecords.filter(
+            (record) => record.recordId !== recordId
+          );
+          return {
+            ...prev,
+            analysisRecords: nextRecords,
+            analysisCount: nextRecords.length,
+          };
+        });
+        setToast({
+          show: true,
+          title: '분석 기록이 삭제되었습니다.',
+          type: 'success',
+          icon: '✅',
+        });
+      } catch (deleteError) {
+        setToast({
+          show: true,
+          title: '삭제에 실패했습니다.',
+          description: getDeleteErrorMessage(deleteError),
+          type: 'warning',
+          icon: '⚠️',
+        });
+      } finally {
+        setDeletingRecordId(null);
+      }
+    },
+    [deletingRecordId]
+  );
 
   return (
     <div className="min-h-screen bg-zinc-100 text-zinc-900">
@@ -71,7 +151,11 @@ export default function MyPage() {
                 <ul className="space-y-4">
                   {data.analysisRecords.map((record) => (
                     <li key={record.recordId}>
-                      <AnalysisHistoryCard record={record} />
+                      <AnalysisHistoryCard
+                        record={record}
+                        onDelete={handleDeleteRecord}
+                        isDeleting={deletingRecordId === record.recordId}
+                      />
                     </li>
                   ))}
                 </ul>
@@ -80,6 +164,14 @@ export default function MyPage() {
           </div>
         )}
       </main>
+      <Toast
+        show={toast.show}
+        onClose={closeToast}
+        title={toast.title}
+        description={toast.description}
+        type={toast.type}
+        icon={toast.icon}
+      />
     </div>
   );
 }


### PR DESCRIPTION
## Summary

마이페이지 분석 기록 카드에서 `DELETE /api/analyze/result/{analysisId}`를 호출해
기록 단건 삭제가 가능하도록 연동했습니다.

- 분석 기록 카드에 삭제 버튼 추가
- 삭제 확인 후 API 호출
- 성공 시 목록/카운트 즉시 갱신
- 실패 시 상태코드(401/403/404) 기반 메시지 분기

## 변경 사항

- `src/apis/userApi.ts`
  - `deleteAnalysisResult(analysisId)` 추가
  - `DeleteAnalysisResultResponse` 타입 추가 (`{ message: string }`)
- `src/pages/mypage/components/AnalysisHistoryCard.tsx`
  - 삭제 버튼 추가
  - 삭제 중 로딩 텍스트(`삭제 중...`) 및 disabled 처리
- `src/pages/mypage/index.tsx`
  - 삭제 핸들러 추가 (`window.confirm` 확인 포함)
  - 성공 시 `analysisRecords`에서 대상 제거 + `analysisCount` 동기화
  - 실패 시 401/403/404/기타 에러 토스트 분기
  - 성공/실패 토스트 표시

## API 스펙 반영

- Endpoint: `DELETE /api/analyze/result/{analysisId}`
- Auth: `Bearer accessToken`
- `analysisId`: UUID
- 성공 응답: JSON 성공 메시지 (`{"message":"success"}`)
- 삭제 범위: 분석 결과만 삭제 (유저 정보 유지)
- 권한: 본인 소유 분석 결과만 삭제 가능

## 테스트 체크리스트

### 기본 동작
- [ ] 마이페이지 분석 기록 카드에 `삭제` 버튼이 노출된다
- [ ] `삭제` 클릭 시 확인창이 뜬다
- [ ] 확인 취소 시 삭제 요청이 발생하지 않는다

### 성공 케이스
- [ ] 삭제 성공 시 성공 토스트가 노출된다
- [ ] 삭제한 카드가 목록에서 즉시 사라진다
- [ ] `총 N건` 카운트가 즉시 감소한다
- [ ] 마지막 1건 삭제 시 빈 상태 문구가 노출된다

### 실패 케이스
- [ ] 401 응답 시 로그인 만료 안내 메시지가 노출된다
- [ ] 403 응답 시 권한 없음 메시지가 노출된다
- [ ] 404 응답 시 이미 삭제/미존재 메시지가 노출된다
- [ ] 기타 에러 시 일반 실패 메시지가 노출된다

### UX/안정성
- [ ] 삭제 진행 중 해당 카드의 삭제 버튼이 비활성화된다
- [ ] 삭제 중 중복 클릭이 방지된다
- [ ] `결과 보기` 링크 동작에는 회귀가 없다

## Out of scope
- 분석 결과 상세 페이지(`/result/:id`)의 별도 삭제 처리