### PR TITLE
[FO-#20] : 프로필 설정 기술 스택 선택 드롭다운 UX 개선

### DIFF
--- a/src/pages/profile-setup/index.tsx
+++ b/src/pages/profile-setup/index.tsx
@@ -148,6 +148,8 @@ export default function ProfileSetupPage() {
   
   const [selectedStacks, setSelectedStacks] = useState<string[]>([]);
   const [stackQuery, setStackQuery] = useState('');
+  const [stackDropdownOpen, setStackDropdownOpen] = useState(false);
+  const stackSelectRef = useRef<HTMLDivElement>(null);
   
   const [isSubmitting, setIsSubmitting] = useState(false);
   const [isInitialLoading, setIsInitialLoading] = useState(true); // 데이터 불러오는 상태
@@ -204,12 +206,35 @@ export default function ProfileSetupPage() {
     return () => document.removeEventListener('mousedown', close);
   }, [jobDropdownOpen]);
 
+  useEffect(() => {
+    if (!stackDropdownOpen) return;
+    const close = (e: MouseEvent) => {
+      if (stackSelectRef.current && !stackSelectRef.current.contains(e.target as Node)) {
+        setStackDropdownOpen(false);
+      }
+    };
+    document.addEventListener('mousedown', close);
+    return () => document.removeEventListener('mousedown', close);
+  }, [stackDropdownOpen]);
+
+  useEffect(() => {
+    if (!stackDropdownOpen) return;
+    const onKeyDown = (e: KeyboardEvent) => {
+      if (e.key === 'Escape') {
+        setStackDropdownOpen(false);
+      }
+    };
+    document.addEventListener('keydown', onKeyDown);
+    return () => document.removeEventListener('keydown', onKeyDown);
+  }, [stackDropdownOpen]);
+
   const canSubmit = selectedStacks.length >= 1 && !isSubmitting;
   const selectedSet = useMemo(() => new Set(selectedStacks), [selectedStacks]);
+  const isStackSearching = stackQuery.trim().length > 0;
 
   const filteredCatalog = useMemo(() => {
     const q = stackQuery.trim().toLowerCase();
-    if (!q) return [];
+    if (!q) return TECH_CATALOG;
     return TECH_CATALOG.filter(
       (item) =>
         item.name.toLowerCase().includes(q) || item.category.toLowerCase().includes(q)
@@ -362,7 +387,7 @@ export default function ProfileSetupPage() {
               </span>
             </div>
             <p className="mb-3 text-xs text-zinc-500 sm:text-sm">
-              기술을 입력하면 연관 검색어가 표시됩니다 (최대 {MAX_STACK}개)
+              기술을 선택하거나 검색해 추가할 수 있습니다 (최대 {MAX_STACK}개)
             </p>
 
             <div
@@ -391,29 +416,42 @@ export default function ProfileSetupPage() {
               )}
             </div>
 
-            <div className="relative">
-              <span
-                className="pointer-events-none absolute left-3.5 top-1/2 -translate-y-1/2 text-zinc-400"
-                aria-hidden
-              >
-                🔍
-              </span>
-              <input
-                type="search"
-                value={stackQuery}
-                onChange={(e) => setStackQuery(e.target.value)}
-                placeholder="기술 이름을 검색하세요"
-                autoComplete="off"
-                className="w-full rounded-2xl border border-zinc-200 bg-zinc-50 py-3 pl-10 pr-4 text-sm text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-orange-400 focus:bg-white focus:ring-2 focus:ring-orange-500/20"
-                aria-label="기술 스택 검색"
-              />
-            </div>
+            <div ref={stackSelectRef}>
+              <div className="relative">
+                <span
+                  className="pointer-events-none absolute left-3.5 top-1/2 z-10 -translate-y-1/2 text-zinc-400"
+                  aria-hidden
+                >
+                  🔍
+                </span>
+                <input
+                  type="search"
+                  value={stackQuery}
+                  onChange={(e) => {
+                    setStackQuery(e.target.value);
+                    setStackDropdownOpen(true);
+                  }}
+                  onFocus={() => setStackDropdownOpen(true)}
+                  onClick={() => setStackDropdownOpen(true)}
+                  placeholder="기술 이름을 검색하세요"
+                  autoComplete="off"
+                  aria-expanded={stackDropdownOpen}
+                  aria-haspopup="listbox"
+                  className="w-full rounded-2xl border border-zinc-200 bg-zinc-50 py-3 pl-10 pr-10 text-sm text-zinc-900 outline-none transition-colors placeholder:text-zinc-400 focus:border-orange-400 focus:bg-white focus:ring-2 focus:ring-orange-500/20"
+                  aria-label="기술 스택 검색 및 선택"
+                />
+                <ChevronDownIcon
+                  className={`pointer-events-none absolute right-3.5 top-1/2 h-5 w-5 -translate-y-1/2 text-zinc-400 transition-transform ${
+                    stackDropdownOpen ? 'rotate-180' : ''
+                  }`}
+                />
+              </div>
 
-            {stackQuery.trim().length > 0 && (
+              {stackDropdownOpen && (
               <div
                 className="mt-2 overflow-hidden rounded-2xl border border-zinc-200 bg-white shadow-sm"
                 role="listbox"
-                aria-label="검색 결과"
+                aria-label={isStackSearching ? '검색 결과' : '기술 스택 선택'}
               >
                 {filteredCatalog.length === 0 ? (
                   <p className="px-4 py-6 text-center text-sm text-zinc-500">검색 결과가 없습니다</p>
@@ -460,7 +498,8 @@ export default function ProfileSetupPage() {
                   {selectedStacks.length} / {MAX_STACK}개 선택됨
                 </div>
               </div>
-            )}
+              )}
+            </div>
           </div>
 
           <button


### PR DESCRIPTION
## Summary

프로필 설정 화면의 기술 스택 선택 UX를 개선
기존에는 검색어를 입력해야만 선택지가 표시
입력창 클릭/포커스 시 전체 목록을 드롭다운으로 바로 보여주도록 변경

## 배경

- 피드백: "기술 이름을 검색하세요" 입력창에서 검색어 없이는 선택지가 보이지 않아 불편함
- 기존 로직: `stackQuery`가 비어 있으면 `filteredCatalog = []`, 목록 UI 미노출

## Changes

- `src/pages/profile-setup/index.tsx`
  - `stackDropdownOpen` 상태 및 `stackSelectRef` 추가
  - 검색어 없을 때 `TECH_CATALOG` 전체 표시
  - input focus/click 시 드롭다운 열기
  - 바깥 클릭 / `Escape`로 드롭다운 닫기
  - 검색 입력 시 목록 필터링 유지
  - `+` 클릭 후 드롭다운 유지 (연속 선택 가능)
  - 안내 문구 변경: "기술을 선택하거나 검색해 추가할 수 있습니다"
  - Chevron 아이콘 및 `aria-expanded` / `aria-haspopup` 추가

## Out of scope

- 카테고리 그룹핑 UI
- BE API / 저장 로직 변경
- dev 전용 로그인 우회

## Test plan (수동)

### 기본 UX
- [ ] `/profile-setup` 접속 가능 (로그인 필요)
- [ ] "기술 이름을 검색하세요" 입력창 **클릭만** 해도 아래 선택지 목록이 표시
- [ ] 입력창 **포커스** 시에도 목록이 표시
- [ ] 목록에 `TECH_CATALOG` 항목들이 스크롤 가능하게 보임

### 검색 + 선택
- [ ] 검색어 입력 시 목록이 name/category 기준으로 필터링
- [ ] 검색어를 지워도 (드롭다운 열린 상태) 전체 목록이 다시 보임
- [ ] `+` 버튼으로 기술 추가 시 상단 태그에 반영
- [ ] 연속으로 여러 기술을 추가할 수 있다 (드롭다운 유지)
- [ ] 이미 선택된 항목은 `추가됨`으로 표시
- [ ] 15개 선택 시 추가 버튼이 disabled 됨

### 닫기 동작
- [ ] 입력창/목록 바깥 클릭 시 드롭다운이 닫힘
- [ ] `Escape` 키 입력 시 드롭다운이 닫힘
- [ ] 목록 내부 `+` 클릭 시 드롭다운이 닫히지 않음

### 회귀 확인
- [ ] 희망 직군 드롭다운 동작에 회귀 없음
- [ ] 기존 선택 태그 `×` 제거 동작 정상
- [ ] `완료` 클릭 시 저장 API 호출 및 `/mypage` 이동 정상
- [ ] `나중에 설정하기` 동작 정상
- [ ] 수정 진입 시 기존 `techStacks` pre-fill 정상

### 빌드
- [ ] `pnpm build` 통과

## Related

- Refs #20