### PR TITLE
[FO-#21]: AppHeader 전 페이지에서 대외활동·공모전 NAV 노출

### DIFF
--- a/src/components/layout/AppHeader.tsx
+++ b/src/components/layout/AppHeader.tsx
@@ -2,7 +2,7 @@ import type { ReactNode } from 'react';
 import NextPlanLogo from '../brand/NextPlanLogo';
 
 type AppHeaderProps = {
-  /** 가운데 NAV (메인 페이지 등에서만 사용) */
+  /** 가운데 NAV (대외활동·공모전 등) */
   centerSlot?: ReactNode;
   /** 페이지별 오른쪽 액션 (예: KakaoLoginButton) */
   rightSlot?: ReactNode;

--- a/src/components/layout/AppLayout.tsx
+++ b/src/components/layout/AppLayout.tsx
@@ -1,19 +1,13 @@
-import { Outlet, useLocation } from 'react-router-dom';
+import { Outlet } from 'react-router-dom';
 import AppHeader from './AppHeader';
 import MainNav from './MainNav';
 import KakaoLoginButton from '../../pages/kakao/component/KakaoLoginButton';
 
 /** 전역 NAV: AppHeader + 페이지 본문(Outlet) */
 export default function AppLayout() {
-  const { pathname } = useLocation();
-  const isMainPage = pathname === '/' || pathname === '/main';
-
   return (
     <>
-      <AppHeader
-        centerSlot={isMainPage ? <MainNav /> : undefined}
-        rightSlot={<KakaoLoginButton />}
-      />
+      <AppHeader centerSlot={<MainNav />} rightSlot={<KakaoLoginButton />} />
       <Outlet />
     </>
   );


### PR DESCRIPTION
## Summary

FO_16에서 메인 페이지(`/`, `/main`)에만 노출되던 헤더 중앙 NAV(대외활동·공모전)를
**AppLayout을 사용하는 모든 페이지**에서 보이도록 변경했습니다.

## 배경

- 기존: `AppLayout`에서 `isMainPage`일 때만 `centerSlot={<MainNav />}` 전달
- 피드백: 마이페이지·게시판 등 다른 화면에서도 대외활동/공모전 진입이 필요함

## Changes

- `src/components/layout/AppLayout.tsx`
  - `useLocation` / `isMainPage` 조건 제거
  - `centerSlot={<MainNav />}` 항상 전달
- `src/components/layout/AppHeader.tsx`
  - `centerSlot` 주석 정리 (메인 전용 → 공통 NAV)

## Out of scope

- 모바일(`sm` 미만) 헤더 중앙 NAV 노출 (`hidden sm:flex` 유지)
- `MainNav` 항목 추가/변경
- 메인 hero에 CTA 버튼 재추가
- `/profile-setup`, `/auth/kakao/callback` (AppLayout 밖 — 헤더 없음)

## Test plan (수동)

### NAV 노출 (데스크톱 `sm` 이상)
- [ ] `/` (메인) — 헤더 가운데 **대외활동**, **공모전** 표시
- [ ] `/mypage` — 동일 NAV 표시
- [ ] `/board/activities` — 동일 NAV 표시
- [ ] `/board/competitions` — 동일 NAV 표시
- [ ] `/board/:category/:id` (상세) — 동일 NAV 표시
- [ ] `/result/:id` — 동일 NAV 표시
- [ ] `/calendar` — 동일 NAV 표시
- [ ] `/login` — 동일 NAV 표시 (AppLayout 사용)

### NAV 미노출 (의도된 동작)
- [ ] `/profile-setup` — 전역 헤더 없음
- [ ] `/auth/kakao/callback` — 전역 헤더 없음

### 링크·활성 상태
- [ ] **대외활동** 클릭 → `/board/activities` 이동
- [ ] **공모전** 클릭 → `/board/competitions` 이동
- [ ] 게시판 페이지에서 해당 메뉴 **활성(오렌지 bold)** 표시
- [ ] 우측 **카카오 로그인 / 마이페이지·로그아웃** 동작 회귀 없음

### 빌드
- [ ] `pnpm build` 통과

## Related

- FO_16: 메인 전용 NAV 최초 도입
- Refs #21